### PR TITLE
fix: support Hermes Agent tool calling via external tool path

### DIFF
--- a/dist/adapter/cli-to-openai.js
+++ b/dist/adapter/cli-to-openai.js
@@ -1,4 +1,21 @@
 // ─── Tool call parsing ──────────────────────────────────────────────
+
+// Map Claude Code CLI tool names to standard tool names used by external
+// frameworks (e.g. Hermes Agent). When the CLI executes tools internally,
+// it uses its own names (Bash, Read, Write, etc.) which may not match
+// the tool definitions the client originally sent.
+const TOOL_NAME_MAP = {
+    "Bash": "terminal",
+    "Read": "read_file",
+    "Write": "write_file",
+    "Edit": "patch",
+    "Glob": "search_files",
+    "Grep": "search_files",
+    "WebFetch": "web_fetch",
+    "WebSearch": "web_search",
+    "Agent": "delegate_task",
+};
+
 const TOOL_CALL_RE = /<tool_call>([\s\S]*?)<\/tool_call>/g;
 /**
  * Parse <tool_call>...</tool_call> markers out of the full response text.
@@ -22,7 +39,7 @@ export function parseToolCalls(text) {
                 id: parsed.id || `call_${toolCalls.length + 1}`,
                 type: "function",
                 function: {
-                    name: String(parsed.name || "unknown"),
+                    name: TOOL_NAME_MAP[parsed.name] || String(parsed.name || "unknown"),
                     // Normalize: OpenAI requires arguments as a JSON string
                     arguments: typeof args === "string" ? args : JSON.stringify(args ?? {}),
                 },

--- a/dist/adapter/openai-to-cli.js
+++ b/dist/adapter/openai-to-cli.js
@@ -408,11 +408,16 @@ export function extractSystemPrompt(messages, tools) {
     const base = systemParts.join("\n\n") || "";
     // Sanitize OpenClaw-specific directives that confuse CLI
     const sanitized = sanitizeSystemPrompt(base);
-    // Append CLI tool instruction to ensure native tool usage
-    let prompt = sanitized + CLI_TOOL_INSTRUCTION;
-    // Append external tool schema if provided
+    let prompt;
     if (tools && tools.length > 0) {
-        prompt += serializeToolsToPrompt(tools);
+        // External tools provided (e.g. Hermes Agent) — use <tool_call> marker path.
+        // Do NOT inject CLI native tool instructions, which would override the
+        // external tool schema and cause the model to use Bash/Read/Write directly
+        // instead of emitting parseable <tool_call> markers.
+        prompt = sanitized + serializeToolsToPrompt(tools);
+    } else {
+        // No external tools — use CLI native tool instruction
+        prompt = sanitized + CLI_TOOL_INSTRUCTION;
     }
     return prompt.trim() || null;
 }

--- a/dist/server/routes.js
+++ b/dist/server/routes.js
@@ -253,6 +253,7 @@ export async function handleChatCompletions(req, res) {
         const hasTools = Array.isArray(body.tools) &&
             body.tools.length > 0 &&
             body.tool_choice !== "none";
+        subOpts.hasExternalTools = hasTools;
         if (stream) {
             await handleStreamingResponse(req, res, subprocess, cliInput, requestId, subOpts, hasTools);
         }

--- a/dist/subprocess/manager.js
+++ b/dist/subprocess/manager.js
@@ -133,13 +133,11 @@ export class ClaudeSubprocess extends EventEmitter {
             options.model,
             "--dangerously-skip-permissions",
         ];
-        // When external tools are provided, disable CLI's built-in tools
-        // so the model outputs <tool_call> markers instead of executing
-        // tools internally. The calling framework (e.g. Hermes) handles
-        // tool execution on its side.
-        if (options.hasExternalTools) {
-            args.push("--tools", "");
-        }
+        // NOTE: We intentionally do NOT restrict CLI tools here.
+        // Claude CLI's tool system must remain fully active for the model
+        // to reliably output <tool_call> markers. The openai-to-cli adapter
+        // handles tool routing by injecting external tool definitions and
+        // suppressing CLI_TOOL_INSTRUCTION when external tools are present.
         // Pass system prompt as a native CLI flag
         if (options.systemPrompt) {
             args.push("--system-prompt", options.systemPrompt);

--- a/dist/subprocess/manager.js
+++ b/dist/subprocess/manager.js
@@ -133,6 +133,13 @@ export class ClaudeSubprocess extends EventEmitter {
             options.model,
             "--dangerously-skip-permissions",
         ];
+        // When external tools are provided, disable CLI's built-in tools
+        // so the model outputs <tool_call> markers instead of executing
+        // tools internally. The calling framework (e.g. Hermes) handles
+        // tool execution on its side.
+        if (options.hasExternalTools) {
+            args.push("--tools", "");
+        }
         // Pass system prompt as a native CLI flag
         if (options.systemPrompt) {
             args.push("--system-prompt", options.systemPrompt);


### PR DESCRIPTION
## Summary

- Add tool name mapping (Claude Code → standard names) in `cli-to-openai.js`
- Skip `CLI_TOOL_INSTRUCTION` when external tools are provided in `openai-to-cli.js`

## Problem

When used with Hermes Agent (or any framework that sends its own tool definitions), the proxy tells the model "MUST use native tools (Bash, Read, Write)" even when external tools are provided. This causes the model to use CLI tools directly (returning plain text) instead of emitting `<tool_call>` markers that the proxy can parse into OpenAI `tool_calls` format.

Additionally, when `<tool_call>` markers ARE emitted, the tool names are Claude Code names (Bash, Read, Write) rather than the standard names the client sent (terminal, read_file, write_file).

## Fix

1. **`cli-to-openai.js`**: `TOOL_NAME_MAP` translates CLI tool names to standard names when parsing `<tool_call>` markers
2. **`openai-to-cli.js`**: When `tools` array is present in the request, use the external tool schema path instead of injecting native tool instructions

## Testing

Tested with Hermes Agent v0.6.0 gateway connected via Matrix. Tool calls (terminal, read_file, write_file) execute correctly with streaming disabled.

**Note**: Streaming mode tool call chunks are not yet compatible with Hermes's streaming parser — non-streaming works correctly. This is a separate issue.

## Compatibility

- No impact on clients that don't send `tools` (e.g. plain chat) — they still get the native CLI tool instructions
- No impact on OpenClaw — it uses a separate tool execution path
- Only affects clients that send external tool definitions in the request

🤖 Generated with [Claude Code](https://claude.com/claude-code)