### PR TITLE
Fix: handle array content blocks in messagesToPrompt

### DIFF
--- a/dist/adapter/openai-to-cli.js
+++ b/dist/adapter/openai-to-cli.js
@@ -401,7 +401,7 @@ ${toolsJson}
 export function extractSystemPrompt(messages, tools) {
     const systemParts = [];
     for (const msg of messages) {
-        if (msg.role === "system") {
+        if (msg.role === "system" || msg.role === "developer") {
             systemParts.push(extractText(msg.content));
         }
     }
@@ -431,7 +431,7 @@ export function extractSystemPrompt(messages, tools) {
  *   When false, both are skipped (CLI handles tools internally).
  */
 export function messagesToPrompt(messages, hasExternalTools = false) {
-    const nonSystemMessages = messages.filter((msg) => msg.role !== "system");
+    const nonSystemMessages = messages.filter((msg) => msg.role !== "system" && msg.role !== "developer");
     const parts = [];
     for (const msg of nonSystemMessages) {
         const text = extractText(msg.content);

--- a/dist/types/openai.d.ts
+++ b/dist/types/openai.d.ts
@@ -33,7 +33,7 @@ export interface OpenAIToolCallDelta {
     };
 }
 export interface OpenAIChatMessage {
-    role: "system" | "user" | "assistant" | "tool";
+    role: "system" | "developer" | "user" | "assistant" | "tool";
     /** null is valid for assistant messages that are pure tool calls */
     content: string | null | Array<{
         type: string;

--- a/src/adapter/openai-to-cli.ts
+++ b/src/adapter/openai-to-cli.ts
@@ -465,7 +465,7 @@ export function extractSystemPrompt(
 ): string | null {
     const systemParts: string[] = [];
     for (const msg of messages) {
-        if (msg.role === "system") {
+        if (msg.role === "system" || msg.role === "developer") {
             systemParts.push(extractText(msg.content));
         }
     }
@@ -500,7 +500,7 @@ export function messagesToPrompt(
     messages: OpenAIChatMessage[],
     hasExternalTools = false
 ): string {
-    const nonSystemMessages = messages.filter((msg) => msg.role !== "system");
+    const nonSystemMessages = messages.filter((msg) => msg.role !== "system" && msg.role !== "developer");
     const parts: string[] = [];
 
     for (const msg of nonSystemMessages) {

--- a/src/types/openai.ts
+++ b/src/types/openai.ts
@@ -44,7 +44,7 @@ export interface OpenAIToolCallDelta {
 // ─── Messages ──────────────────────────────────────────────────────
 
 export interface OpenAIChatMessage {
-    role: "system" | "user" | "assistant" | "tool";
+    role: "system" | "developer" | "user" | "assistant" | "tool";
     /** null is valid for assistant messages that are pure tool calls */
     content: string | null | Array<{ type: string; text?: string; [key: string]: unknown }>;
     tool_calls?: OpenAIToolCall[];


### PR DESCRIPTION
## Summary

- **Add `"developer"` role support**: OpenAI's newer API versions use `"developer"` as an alias for `"system"`. Messages with this role were falling through to the `default` case in `messagesToPrompt()`, appearing as unlabeled text in the conversation prompt instead of being properly extracted as system prompts.
- **Update type definitions**: Added `"developer"` to the `OpenAIChatMessage.role` union type in both source and dist declaration files.
- **Ensure array content blocks are handled**: This repo already has the `extractText()` helper that correctly handles content as `[{type:"text", text:"hello"}]` arrays. The `"developer"` role was the remaining gap for full OpenAI API compatibility, affecting clients like OpenClaw that may send content in array format with the developer role.

## What was broken

When an OpenAI-compatible client (e.g., OpenClaw) sent a message with `role: "developer"`:
1. `extractSystemPrompt()` skipped it (only checked for `"system"`)
2. `messagesToPrompt()` didn't filter it out, so it fell through to the `default` case
3. The developer message content appeared as unlabeled text in the conversation prompt instead of being treated as a system-level instruction

## Files changed

- `src/types/openai.ts` — Added `"developer"` to role union type
- `src/adapter/openai-to-cli.ts` — Handle `"developer"` in `extractSystemPrompt()` and filter it in `messagesToPrompt()`
- `dist/types/openai.d.ts` — Updated compiled type declaration
- `dist/adapter/openai-to-cli.js` — Updated compiled JS

## Test plan

- [ ] Send a chat completion request with `role: "developer"` messages and verify they are extracted as system prompts (not conversation text)
- [ ] Send a chat completion request with `content` as an array of content blocks `[{type:"text", text:"hello"}]` and verify text is extracted correctly (already working via `extractText()`)
- [ ] Verify existing `role: "system"` messages continue to work as before
- [ ] Verify normal `role: "user"` and `role: "assistant"` messages are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)