### PR TITLE
Spawn Claude CLI from $HOME so user permission allowlist loads

### DIFF
--- a/dist/subprocess/manager.js
+++ b/dist/subprocess/manager.js
@@ -9,7 +9,16 @@ import { EventEmitter } from "events";
 import path from "path";
 import fs from "fs";
 import { isAssistantMessage, isResultMessage, isContentDelta, } from "../types/claude-cli.js";
-const PROXY_CWD = path.join(process.env.HOME || "/tmp", ".openclaw", "workspace");
+// Spawn Claude CLI subprocesses from $HOME so that Claude Code's
+// project-scoped settings hierarchy resolves the user's
+// ~/.claude/settings.local.json allowlist. Spawning from any other
+// directory (including ~/.openclaw/workspace) makes Claude Code look
+// for a non-existent project-local settings file and fall back to
+// ~/.claude/settings.json — which typically has no permissions section,
+// causing every Bash invocation to be gated. See incident notes
+// 2026-04-07: Apr 3 Claude CLI release tightened the settings lookup
+// to project-root-only, which broke proxy-spawned subprocesses.
+const PROXY_CWD = process.env.HOME || "/tmp";
 // ── Gateway token resolution ────────────────────────────────────
 // Read OPENCLAW_GATEWAY_TOKEN from openclaw.json if not in env.
 // This enables oc-tool (cross-channel messaging, browser, cron, etc.)

--- a/src/subprocess/manager.ts
+++ b/src/subprocess/manager.ts
@@ -21,11 +21,16 @@ import type {
 } from "../types/claude-cli.js";
 import type { ClaudeModel } from "../adapter/openai-to-cli.js";
 
-const PROXY_CWD = path.join(
-    process.env.HOME || "/tmp",
-    ".openclaw",
-    "workspace"
-);
+// Spawn Claude CLI subprocesses from $HOME so that Claude Code's
+// project-scoped settings hierarchy resolves the user's
+// ~/.claude/settings.local.json allowlist. Spawning from any other
+// directory (including ~/.openclaw/workspace) makes Claude Code look
+// for a non-existent project-local settings file and fall back to
+// ~/.claude/settings.json — which typically has no permissions section,
+// causing every Bash invocation to be gated. See incident notes
+// 2026-04-07: Apr 3 Claude CLI release tightened the settings lookup
+// to project-root-only, which broke proxy-spawned subprocesses.
+const PROXY_CWD = process.env.HOME || "/tmp";
 
 // ── Gateway token resolution ────────────────────────────────────
 // Read OPENCLAW_GATEWAY_TOKEN from openclaw.json if not in env.


### PR DESCRIPTION
## Problem

After Claude CLI's 2026-04-03 release, every Bash invocation by a CLI subprocess spawned via this proxy gets gated by the default permission flow. The user's `~/.claude/settings.local.json` allowlist is silently ignored, and API responses come back as natural-language `"I need approval / check /allowed-tools"` text with no `tool_calls`.

## Root cause

Claude Code's settings hierarchy is **project-scoped**: it looks for `.claude/settings.local.json` relative to the spawn cwd. The proxy was spawning `claude` from `~/.openclaw/workspace`, so Claude Code looked for `~/.openclaw/workspace/.claude/settings.local.json` (which doesn't exist) and fell back to `~/.claude/settings.json` (typically empty of permissions).

The 2026-04-03 upstream Claude CLI release tightened this lookup so that previously-loaded user-level locations no longer fall through. Spawning from any directory other than the user's home now means the user's allowlist never loads.

## Fix

Spawn from `$HOME`. Claude Code then treats the user home as the project root and finds `~/.claude/settings.local.json` in its expected location.

```ts
// Before
const PROXY_CWD = path.join(process.env.HOME || "/tmp", ".openclaw", "workspace");

// After
const PROXY_CWD = process.env.HOME || "/tmp";
```

## Verification

Locally, with this patch, a `POST /v1/chat/completions` request asking the model to run `curl http://.../health` and `rclone lsd remote:` returns the actual command output instead of the permission-prompt text. No other behavior changes.

## Compatibility

The previous `~/.openclaw/workspace` cwd was not referenced by anything else in the codebase (`grep -rn PROXY_CWD` returns only the spawn site).