### PR TITLE
Refactor standalone server with daemon/service management and request tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,27 +48,57 @@ No third-party servers. Everything runs locally. Requests go through Anthropic's
 
 ```bash
 npm install -g claude-max-api-proxy
-
-# Foreground (Ctrl+C to stop)
-claude-max-api                  # default port 3456
-claude-max-api 3457             # custom port
-
-# Background daemon
-claude-max-api start            # daemonize, return immediately
-claude-max-api status           # show pid + port if running
-claude-max-api logs -f          # follow the daemon log
-claude-max-api stop             # SIGTERM the daemon
-claude-max-api restart          # stop + start
 ```
 
-State files for the background daemon live under `~/.claude-max-api/`:
+The global install registers a **user-level service** (launchd on macOS, a
+systemd user unit on Linux) that auto-starts on login and restarts on crash.
+No extra steps — once `npm install -g` finishes you can already
+`curl http://localhost:3456/health`.
+
+```bash
+# Service commands (launchd / systemctl --user under the hood)
+claude-max-api status              # service + process state
+claude-max-api stop                # stop the service
+claude-max-api start               # start the service
+claude-max-api restart             # restart the service
+claude-max-api logs -f             # follow the service log
+
+# Manual service management (rarely needed after a global install)
+claude-max-api install-service [port]   # register/update the unit file
+claude-max-api uninstall-service        # stop and remove the unit file
+
+# Foreground (development / debugging; no service involvement)
+claude-max-api                     # Ctrl+C to stop, default port 3456
+claude-max-api 3457                # custom port
+```
+
+The post-install hook skips automatic service registration when:
+- you ran `npm install` *without* `-g` (local checkout)
+- you ran it via `sudo` (the unit would be owned by root, so we print a note
+  and let you run `claude-max-api install-service` as your normal user)
+- you're on a platform with no supported service backend (non-systemd Linux,
+  Windows, …). In that case `start` falls back to a self-detached daemon.
+
+State files live under `~/.claude-max-api/`:
 
 | File | Purpose |
 |---|---|
-| `~/.claude-max-api/proxy.pid` | JSON pidfile (`{ pid, port, startedAt }`) |
-| `~/.claude-max-api/proxy.log` | Combined stdout + stderr from the daemon |
+| `~/.claude-max-api/proxy.pid` | JSON pidfile (`{ pid, port, startedAt }`) written by the running process |
+| `~/.claude-max-api/proxy.log` | Combined stdout + stderr from the service |
 
-`claude-max-api status` exits 0 when running and 3 (systemd convention) when not, so shell scripts can react to it.
+Unit files:
+
+| Platform | Path |
+|---|---|
+| macOS    | `~/Library/LaunchAgents/com.claude-max-api.plist` |
+| Linux (systemd) | `~/.config/systemd/user/claude-max-api.service` |
+
+`claude-max-api status` exits 0 when running and 3 (systemd convention) when
+not, so shell scripts can react to it.
+
+> **Changing the port** — the port is baked into the service unit. To change
+> it, run `claude-max-api install-service <new-port>`; that rewrites the unit
+> file and restarts the service.
 
 ### Test
 
@@ -123,49 +153,35 @@ npm run start    # starts the server
 
 Full model family support with version pinning (e.g. `claude-opus-4-5-20251101`, `claude-sonnet-4-20250514`).
 
-### Auto-Start on macOS
+### Auto-Start on Login
 
-For most users `claude-max-api start` (see *Install & Run*) is enough — run it from your shell profile or a manual invocation and the daemon survives the terminal closing. If you also need it to come up on every login or restart automatically after a crash, create `~/Library/LaunchAgents/com.claude-max-api.plist`:
+Auto-start is handled by the post-install hook — after `npm install -g
+claude-max-api-proxy` the service is already registered and running. If you
+built from source or the auto-install was skipped (running as root,
+unsupported platform), register it manually:
 
-```xml
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
-  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-  <dict>
-    <key>Label</key>
-    <string>com.claude-max-api</string>
-    <key>RunAtLoad</key>
-    <true/>
-    <key>KeepAlive</key>
-    <dict>
-      <key>SuccessfulExit</key>
-      <false/>
-    </dict>
-    <key>ProgramArguments</key>
-    <array>
-      <string>/opt/homebrew/bin/node</string>
-      <string>/opt/homebrew/lib/node_modules/claude-max-api-proxy/dist/server/standalone.js</string>
-    </array>
-    <key>EnvironmentVariables</key>
-    <dict>
-      <key>HOME</key>
-      <string>/Users/YOUR_USERNAME</string>
-      <key>PATH</key>
-      <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
-    </dict>
-    <key>StandardOutPath</key>
-    <string>/tmp/claude-max-api.log</string>
-    <key>StandardErrorPath</key>
-    <string>/tmp/claude-max-api.err.log</string>
-  </dict>
-</plist>
-```
-
-Then load it:
 ```bash
-launchctl load ~/Library/LaunchAgents/com.claude-max-api.plist
+claude-max-api install-service           # default port 3456
+claude-max-api install-service 3457      # custom port (rewrites the unit file)
 ```
+
+This writes a LaunchAgent (`~/Library/LaunchAgents/com.claude-max-api.plist`)
+on macOS or a systemd user unit
+(`~/.config/systemd/user/claude-max-api.service`) on Linux, then loads and
+starts it. Removal is symmetric:
+
+```bash
+claude-max-api uninstall-service
+```
+
+> **macOS note** — the service runs in the GUI user session (`gui/<uid>`
+> domain). It starts on login and stops on logout; it does not run while no
+> user is logged in.
+>
+> **Linux note** — the service uses `systemctl --user`, so it starts on
+> login too. If you need it to keep running across logout (e.g. a headless
+> box accessed via SSH), enable lingering once:
+> `sudo loginctl enable-linger $USER`.
 
 ## OpenClaw Integration
 

--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ npm run start    # starts the server
 | `CLAUDE_PROXY_PROMPT_BUDGET_BYTES` | No | Soft cap on rendered prompt size in UTF-8 bytes (default 100000). Oldest messages are dropped when exceeded. |
 | `OPENCLAW_GATEWAY_TOKEN` | No | OpenClaw gateway auth token. Falls back to `~/.openclaw/openclaw.json` if unset. |
 | `OPENCLAW_GATEWAY_URL` | No | OpenClaw gateway base URL (default `http://localhost:18789`). |
+| `CLAUDE_PROXY_SAFE_MODE` | No | Set to `1` to drop `--dangerously-skip-permissions` from the spawned CLI (interactive prompts come back; most automated flows will hang). See *Security*. |
+| `CLAUDE_PROXY_ALLOW_CORS_ANY` | No | Set to `1` to restore the legacy `Access-Control-Allow-Origin: *` behavior (otherwise CORS is limited to local origins). |
 
 ### Available Models
 
@@ -200,6 +202,25 @@ There is no `src/session/` any more — see the **Stateless per-request** note i
 - **No stored credentials** — Authentication handled by Claude CLI's OS keychain
 - **No hardcoded secrets** — All sensitive config via environment variables or external config files
 - **Local only by default** — Binds to `127.0.0.1`, not exposed to network
+- **CORS limited to local origins** by default — set `CLAUDE_PROXY_ALLOW_CORS_ANY=1` to revert to `*`
+
+### ⚠️ Threat model: who can run code on your host
+
+By default the proxy launches `claude --dangerously-skip-permissions`, which lets the model accept tool calls without an interactive permission prompt. Combined with the `Bash` tool, **anything that reaches the proxy can run arbitrary shell commands on the host as the user running the proxy**. The default 127.0.0.1 bind is the main thing keeping that from being a remote-code-execution surface.
+
+Treat the proxy as if it were a local shell:
+
+- Do **not** expose the listening port to other machines, containers, or VLANs
+- Do **not** run untrusted clients against it (browser extensions, third-party agents, etc.)
+- The CORS tightening (PR #21) protects against drive-by browser tabs but not against deliberate local callers
+
+If you need a hardened mode, set:
+
+```bash
+export CLAUDE_PROXY_SAFE_MODE=1
+```
+
+This drops `--dangerously-skip-permissions` from the spawned CLI, restoring the interactive permission prompts. The catch: most automated agent flows (OpenClaw, scheduled tasks, voice transcription pipelines) will hang waiting for a human to approve each tool call. Safe mode is suitable for one-off interactive use, not for unattended bot deployments.
 
 ## Tips
 

--- a/README.md
+++ b/README.md
@@ -48,8 +48,27 @@ No third-party servers. Everything runs locally. Requests go through Anthropic's
 
 ```bash
 npm install -g claude-max-api-proxy
-claude-max-api   # starts on http://localhost:3456
+
+# Foreground (Ctrl+C to stop)
+claude-max-api                  # default port 3456
+claude-max-api 3457             # custom port
+
+# Background daemon
+claude-max-api start            # daemonize, return immediately
+claude-max-api status           # show pid + port if running
+claude-max-api logs -f          # follow the daemon log
+claude-max-api stop             # SIGTERM the daemon
+claude-max-api restart          # stop + start
 ```
+
+State files for the background daemon live under `~/.claude-max-api/`:
+
+| File | Purpose |
+|---|---|
+| `~/.claude-max-api/proxy.pid` | JSON pidfile (`{ pid, port, startedAt }`) |
+| `~/.claude-max-api/proxy.log` | Combined stdout + stderr from the daemon |
+
+`claude-max-api status` exits 0 when running and 3 (systemd convention) when not, so shell scripts can react to it.
 
 ### Test
 
@@ -106,7 +125,7 @@ Full model family support with version pinning (e.g. `claude-opus-4-5-20251101`,
 
 ### Auto-Start on macOS
 
-Create `~/Library/LaunchAgents/com.claude-max-api.plist`:
+For most users `claude-max-api start` (see *Install & Run*) is enough — run it from your shell profile or a manual invocation and the daemon survives the terminal closing. If you also need it to come up on every login or restart automatically after a crash, create `~/Library/LaunchAgents/com.claude-max-api.plist`:
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>

--- a/README.md
+++ b/README.md
@@ -26,11 +26,12 @@ No third-party servers. Everything runs locally. Requests go through Anthropic's
 
 - **OpenAI-compatible API** — Drop-in replacement for any client that supports `POST /v1/chat/completions`
 - **Streaming & non-streaming** — Full SSE streaming support with direct delta forwarding
-- **Session persistence** — Conversations maintain context across messages via CLI session resume
+- **Stateless per-request** — Each call spawns a fresh CLI subprocess; conversation history is supplied by the client on every turn (the proxy itself does not retain session state). The session manager that used to live in `src/session/` was removed in v1.3.x.
 - **No turn limits** — The CLI runs as many tool-call rounds as needed for complex tasks
-- **Activity timeout** — 10-minute inactivity watchdog catches stuck processes while letting long tasks complete
-- **Telegram progress** — Real-time progress updates showing which tools are running (optional)
-- **No native dependencies** — Pure JS, uses `child_process.spawn()` with piped stdio and `--output-format stream-json`
+- **Activity timeout** — Configurable inactivity watchdog (`CLAUDE_PROXY_ACTIVITY_TIMEOUT_MS`, default 10 minutes) catches stuck processes while letting long tasks complete; both stdout and stderr count as activity
+- **Concurrency cap** — `CLAUDE_PROXY_MAX_CONCURRENT` (default 4) bounds in-flight requests so a burst cannot fork unbounded CLI subprocesses
+- **Prompt budget** — `CLAUDE_PROXY_PROMPT_BUDGET_BYTES` (default 100 KiB) drops the oldest history when long conversations exceed the budget
+- **No native dependencies** — Pure JS, uses `child_process.spawn()` with piped stdio and `--output-format stream-json`. Prompt and system instructions are piped via stdin to avoid Linux ARG_MAX (E2BIG) on long histories.
 
 ## Quick Start
 
@@ -84,8 +85,12 @@ npm run start    # starts the server
 
 | Variable | Required | Description |
 |----------|----------|-------------|
-| `TELEGRAM_NOTIFY_ID` | No | Telegram user ID for timeout notifications |
 | `DEBUG` | No | Set to any value to enable request logging |
+| `CLAUDE_PROXY_MAX_CONCURRENT` | No | Max concurrent chat-completions requests (default 4). Excess requests get a 429 with Retry-After. |
+| `CLAUDE_PROXY_ACTIVITY_TIMEOUT_MS` | No | Inactivity watchdog timeout in ms (default 600000 = 10 min). Resets on stdout *or* stderr from the CLI. |
+| `CLAUDE_PROXY_PROMPT_BUDGET_BYTES` | No | Soft cap on rendered prompt size in UTF-8 bytes (default 100000). Oldest messages are dropped when exceeded. |
+| `OPENCLAW_GATEWAY_TOKEN` | No | OpenClaw gateway auth token. Falls back to `~/.openclaw/openclaw.json` if unset. |
+| `OPENCLAW_GATEWAY_URL` | No | OpenClaw gateway base URL (default `http://localhost:18789`). |
 
 ### Available Models
 
@@ -173,20 +178,21 @@ When used with [OpenClaw](https://openclaw.dev), this proxy supports all native 
 ```
 src/
 ├── adapter/
-│   ├── openai-to-cli.ts    # OpenAI request → CLI prompt + system prompt
-│   └── cli-to-openai.ts    # CLI JSON stream → OpenAI response format
+│   ├── openai-to-cli.ts    # OpenAI request → CLI prompt + inlined system instructions
+│   └── cli-to-openai.ts    # CLI JSON stream → OpenAI response format (incl. <tool_call> parsing)
 ├── subprocess/
-│   └── manager.ts           # CLI subprocess lifecycle & activity timeout
-├── session/
-│   └── manager.ts           # Conversation → CLI session mapping
+│   └── manager.ts          # CLI subprocess lifecycle, activity watchdog, env scrubbing
 ├── server/
-│   ├── routes.ts             # SSE streaming, progress notifications
-│   ├── index.ts              # Express server setup
-│   └── standalone.ts         # Entry point
-└── types/
-    ├── openai.ts             # OpenAI API type definitions
-    └── claude-cli.ts         # CLI stream-json event types
+│   ├── routes.ts           # /v1/chat/completions: SSE streaming, bleed/auth-probe/concurrency
+│   ├── index.ts            # Express server setup, CORS, error middleware
+│   └── standalone.ts       # `claude-max-api` CLI entry point
+├── types/
+│   ├── openai.ts           # OpenAI API type definitions
+│   └── claude-cli.ts       # CLI stream-json event types
+└── index.ts                # OpenClaw plugin registration
 ```
+
+There is no `src/session/` any more — see the **Stateless per-request** note in *Key Features*.
 
 ## Security
 

--- a/dist/adapter/cli-to-openai.js
+++ b/dist/adapter/cli-to-openai.js
@@ -167,18 +167,12 @@ export function cliResultToOpenai(result, requestId) {
 }
 // ─── Helpers ───────────────────────────────────────────────────────
 /**
- * Normalize Claude model names to a consistent format
- * e.g., "claude-sonnet-4-5-20250929" -> "claude-sonnet-4"
+ * Normalize Claude model names by stripping date suffixes.
+ * e.g., "claude-sonnet-4-6-20250929" -> "claude-sonnet-4-6"
  */
 function normalizeModelName(model) {
     if (!model || typeof model !== "string")
         return "claude-sonnet-4";
-    if (model.includes("opus"))
-        return "claude-opus-4";
-    if (model.includes("sonnet"))
-        return "claude-sonnet-4";
-    if (model.includes("haiku"))
-        return "claude-haiku-4";
-    return model;
+    return model.replace(/-\d{8}$/, "");
 }
 //# sourceMappingURL=cli-to-openai.js.map

--- a/dist/adapter/cli-to-openai.js
+++ b/dist/adapter/cli-to-openai.js
@@ -1,5 +1,3 @@
-// ─── Tool call parsing ──────────────────────────────────────────────
-const TOOL_CALL_RE = /<tool_call>([\s\S]*?)<\/tool_call>/g;
 /**
  * Parse <tool_call>...</tool_call> markers out of the full response text.
  *
@@ -12,9 +10,10 @@ const TOOL_CALL_RE = /<tool_call>([\s\S]*?)<\/tool_call>/g;
  */
 export function parseToolCalls(text) {
     const toolCalls = [];
-    // Reset lastIndex since the regex is module-level with /g flag
-    TOOL_CALL_RE.lastIndex = 0;
-    const textWithoutToolCalls = text.replace(TOOL_CALL_RE, (_, inner) => {
+    // Local regex instance: a module-level /g RegExp shares lastIndex across
+    // all callers, which is unsafe under concurrent requests.
+    const re = /<tool_call>([\s\S]*?)<\/tool_call>/g;
+    const textWithoutToolCalls = text.replace(re, (_, inner) => {
         try {
             const parsed = JSON.parse(inner.trim());
             const args = parsed.arguments;

--- a/dist/adapter/cli-to-openai.test.d.ts
+++ b/dist/adapter/cli-to-openai.test.d.ts
@@ -1,0 +1,2 @@
+export {};
+//# sourceMappingURL=cli-to-openai.test.d.ts.map

--- a/dist/adapter/cli-to-openai.test.js
+++ b/dist/adapter/cli-to-openai.test.js
@@ -1,0 +1,60 @@
+/**
+ * Unit tests for the Claude CLI → OpenAI adapter pure functions.
+ * Run with: npm test
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { parseToolCalls } from "./cli-to-openai.js";
+test("parseToolCalls: extracts a single well-formed tool call", () => {
+    const text = `prelude\n<tool_call>{"id":"call_1","name":"get_weather","arguments":{"city":"Tokyo"}}</tool_call>\ntrailer`;
+    const result = parseToolCalls(text);
+    assert.equal(result.hasToolCalls, true);
+    assert.equal(result.toolCalls.length, 1);
+    assert.equal(result.toolCalls[0].id, "call_1");
+    assert.equal(result.toolCalls[0].function.name, "get_weather");
+    // arguments must be a JSON string per OpenAI spec
+    assert.equal(typeof result.toolCalls[0].function.arguments, "string");
+    assert.equal(result.toolCalls[0].function.arguments, '{"city":"Tokyo"}');
+});
+test("parseToolCalls: extracts multiple tool calls in order", () => {
+    const text = `<tool_call>{"id":"call_a","name":"a","arguments":{}}</tool_call>` +
+        `\n<tool_call>{"id":"call_b","name":"b","arguments":{"x":1}}</tool_call>`;
+    const result = parseToolCalls(text);
+    assert.equal(result.toolCalls.length, 2);
+    assert.equal(result.toolCalls[0].id, "call_a");
+    assert.equal(result.toolCalls[1].id, "call_b");
+    assert.equal(result.toolCalls[1].function.arguments, '{"x":1}');
+});
+test("parseToolCalls: arguments already as a string is preserved verbatim", () => {
+    const text = `<tool_call>{"id":"call_1","name":"a","arguments":"{\\"raw\\":true}"}</tool_call>`;
+    const result = parseToolCalls(text);
+    assert.equal(result.toolCalls[0].function.arguments, '{"raw":true}');
+});
+test("parseToolCalls: ignores malformed JSON inside tool_call without crashing", () => {
+    const text = `<tool_call>not actually json</tool_call> trailing prose`;
+    const result = parseToolCalls(text);
+    // Malformed call is silently dropped, but the surrounding text still loses the marker
+    assert.equal(result.hasToolCalls, false);
+    assert.equal(result.textWithoutToolCalls, "trailing prose");
+});
+test("parseToolCalls: text without markers passes through unchanged", () => {
+    const text = "Just a normal answer.";
+    const result = parseToolCalls(text);
+    assert.equal(result.hasToolCalls, false);
+    assert.equal(result.toolCalls.length, 0);
+    assert.equal(result.textWithoutToolCalls, "Just a normal answer.");
+});
+test("parseToolCalls: concurrent invocations do not share state", () => {
+    // Regression for the previous module-level /g RegExp lastIndex bug.
+    // Run a long parse and a short parse interleaved and check both finish
+    // with the right results.
+    const longText = `<tool_call>{"id":"long","name":"l","arguments":{"k":"${"v".repeat(1000)}"}}</tool_call>`;
+    const shortText = `<tool_call>{"id":"short","name":"s","arguments":{}}</tool_call>`;
+    const a = parseToolCalls(longText);
+    const b = parseToolCalls(shortText);
+    const c = parseToolCalls(longText);
+    assert.equal(a.toolCalls[0].id, "long");
+    assert.equal(b.toolCalls[0].id, "short");
+    assert.equal(c.toolCalls[0].id, "long");
+});
+//# sourceMappingURL=cli-to-openai.test.js.map

--- a/dist/adapter/openai-to-cli.d.ts
+++ b/dist/adapter/openai-to-cli.d.ts
@@ -21,13 +21,17 @@ export declare function extractModel(model: string): ClaudeModel;
  */
 export declare function extractSystemPrompt(messages: OpenAIChatMessage[], tools?: OpenAITool[]): string | null;
 /**
- * Convert OpenAI messages array to a single prompt string for Claude CLI
+ * Convert OpenAI messages array to a single prompt string for Claude CLI.
  *
  * Claude Code CLI in --print mode expects a single prompt, not a conversation.
- * System messages are extracted separately (passed via --system-prompt flag).
- * XML tool patterns in assistant messages are cleaned by cleanAssistantContent()
- * to prevent the model from mimicking XML format instead of using native tools.
+ * System messages are extracted separately (see extractSystemPrompt). XML tool
+ * patterns in assistant messages are cleaned by cleanAssistantContent() to
+ * prevent the model from mimicking XML format instead of using native tools.
  * NO_REPLY assistant messages are filtered out (OpenClaw silent reply tokens).
+ *
+ * If the rendered prompt exceeds PROMPT_BUDGET_BYTES, the oldest messages
+ * are dropped (the most recent message is always retained) and a truncation
+ * marker is prepended.
  *
  * @param hasExternalTools - When true, assistant messages with tool_calls are
  *   rendered as <tool_call> markers (for multi-turn tool conversations), and

--- a/dist/adapter/openai-to-cli.js
+++ b/dist/adapter/openai-to-cli.js
@@ -8,8 +8,12 @@
 function extractText(content) {
     if (content === null || content === undefined)
         return "";
-    if (typeof content === "string")
-        return content;
+    if (typeof content === "string") {
+        // Some upstream serializers stringify null content as the literal
+        // four-letter word "null". Treat that as empty so callers don't
+        // need a separate guard.
+        return content === "null" ? "" : content;
+    }
     if (Array.isArray(content)) {
         return content
             .filter((c) => c.type === "text" && typeof c.text === "string")
@@ -469,7 +473,7 @@ export function messagesToPrompt(messages, hasExternalTools = false) {
                     break;
                 }
                 // Skip assistant messages that are purely tool_calls with no text
-                if (msg.tool_calls && (!text || text === "null"))
+                if (msg.tool_calls && !text)
                     break;
                 // Clean XML tool patterns to prevent CLI from mimicking them
                 const cleaned = cleanAssistantContent(text);

--- a/dist/adapter/openai-to-cli.js
+++ b/dist/adapter/openai-to-cli.js
@@ -171,8 +171,18 @@ export function extractModel(model) {
 // ─── CLI tool instruction ──────────────────────────────────────────
 /**
  * CLI tool usage instruction appended to the system prompt.
- * This ensures the CLI model uses its native tool system (Bash, Read, Write, etc.)
- * instead of outputting XML-formatted tool calls as text.
+ *
+ * This is the *minimum* set of rules the proxy depends on:
+ *  1. Use native CLI tools, never XML stand-ins.
+ *  2. Always actually transcribe audio rather than hallucinate.
+ *  3. The MEDIA: / FILE: / [[…]] response directives the proxy parses.
+ *  4. The 10-minute activity-timeout escape hatch.
+ *  5. Final-response formatting (target language, no internal thinking).
+ *
+ * Detailed oc-tool subcommand usage used to be documented inline here, but
+ * that bloated every request by 4-5 KiB of input tokens and was constantly
+ * out of date. The model can rediscover it on demand via `oc-tool --help`
+ * (and `oc-tool <subcommand> --help`), since it has Bash anyway.
  */
 const CLI_TOOL_INSTRUCTION = `
 
@@ -196,109 +206,26 @@ When you receive a voice/audio message (indicated by [media attached: ...ogg] or
 - Transcribe directly with: curl -s -X POST "https://api.groq.com/openai/v1/audio/transcriptions" -H "Authorization: Bearer $GROQ_API_KEY" -H "Content-Type: multipart/form-data" -F "file=@/path/to/file.ogg" -F "model=whisper-large-v3-turbo" -F "language=zh"
 - If transcription fails, say so honestly — do NOT make up a transcription
 
-## OpenClaw Tools (via oc-tool)
-Use \`oc-tool\` in Bash for OpenClaw platform operations. Args are always JSON.
+## OpenClaw Platform Tools (via oc-tool in Bash)
+\`oc-tool\` is on PATH. It exposes the OpenClaw platform: cross-channel
+messaging (telegram/slack/discord), browser automation, cron, sessions,
+TTS, web search/fetch, image analysis, and more. All arguments are JSON.
 
-### Browser
-  oc-tool browser status                                      # connection status
-  oc-tool browser tabs                                        # list open tabs
-  oc-tool browser tab new                                     # open new tab
-  oc-tool browser tab select 2                                # switch to tab 2
-  oc-tool browser tab close 2                                 # close tab 2
-  oc-tool browser navigate https://example.com                # go to URL
-  oc-tool browser snapshot                                    # accessibility tree (returns refs like e6, e12)
-  oc-tool browser snapshot --interactive --compact            # interactive elements only, compact
-  oc-tool browser snapshot --selector "#main" --interactive   # scoped to a CSS selector
-  oc-tool browser screenshot                                  # capture page image (returns MEDIA: path)
-  oc-tool browser screenshot --full-page                      # full page screenshot
-  oc-tool browser pdf                                         # render page as PDF (returns MEDIA: path)
-  oc-tool browser console --level error                       # get console errors
-  oc-tool browser click e12                                   # click element by ref
-  oc-tool browser click e12 --double                          # double-click
-  oc-tool browser type e3 "hello" --submit                    # type text, press Enter after
-  oc-tool browser press Enter                                 # press a key (Enter, Tab, Escape, etc.)
-  oc-tool browser hover e44                                   # hover over element
-  oc-tool browser drag e10 e11                                # drag from one ref to another
-  oc-tool browser select e9 OptionA OptionB                   # select dropdown options
-  oc-tool browser fill --fields '[{"ref":"e1","type":"text","value":"Ada"}]'  # fill multiple fields
-  oc-tool browser evaluate --fn '(el) => el.textContent' --ref e7             # run JS on element
-  oc-tool browser upload /tmp/file.pdf                        # upload file to active input
-  oc-tool browser dialog --accept                             # accept JS alert/confirm/prompt
-  oc-tool browser wait --text "Done"                          # wait until text appears on page
-  oc-tool browser wait "#main" --url "**/dash" --load networkidle  # wait for navigation
-  oc-tool browser highlight e12                               # highlight element (debug)
-  oc-tool browser scrollintoview e12                          # scroll element into view
-Browser rules:
-- Always run snapshot first to get refs (e.g. e6, e12) before clicking/typing
-- Refs come from snapshot output — never guess them
-- Use --interactive flag on snapshot to show only clickable elements
+Discover usage on demand instead of guessing:
+  oc-tool --help                       # list every subcommand
+  oc-tool <subcommand> --help          # full syntax + examples
 
-### Cron (Scheduled Tasks)
-  oc-tool cron status                                # cron system status
-  oc-tool cron list                                  # list all jobs
-  oc-tool cron add '{"name":"job-name","schedule":{"kind":"cron","expression":"0 8 * * *","tz":"Asia/Taipei"},"payload":{"kind":"agentTurn","message":"your prompt"},"deliver":"announce","channel":"telegram"}'
-  oc-tool cron add '{"name":"once","schedule":{"kind":"at","at":"2026-02-17T09:00:00+08:00"},"payload":{"kind":"agentTurn","message":"..."},"deliver":"announce"}'
-  oc-tool cron add '{"name":"every-30m","schedule":{"kind":"every","intervalMs":1800000},"payload":{"kind":"agentTurn","message":"..."}}'
-  oc-tool cron update '{"name":"job-name","schedule":{...}}'  # patch existing job
-  oc-tool cron remove '{"name":"job-name"}'
-  oc-tool cron run '{"name":"job-name"}'             # trigger immediately
-  oc-tool cron runs '{"name":"job-name"}'            # list past run history
-Schedule kinds: "cron" (5-field + timezone), "at" (one-shot ISO timestamp), "every" (intervalMs)
-Payload kinds: "agentTurn" (isolated run with message), "systemEvent" (heartbeat event)
-Deliver: "announce" (send result to chat), "none" (internal only)
+Common subcommand entry points:
+  oc-tool browser    — navigate, snapshot, screenshot, click, type, etc.
+  oc-tool message    — send/read/edit/react/pin across channels
+  oc-tool cron       — list/add/update/remove/run scheduled jobs
+  oc-tool sessions_* — list/history/status of conversation sessions
+  oc-tool tts speak  — generate voice audio (returns MEDIA: path)
+  oc-tool web_search / oc-tool web_fetch
+  oc-tool image      — describe/analyze a local image file
 
-### Message (Send to Channels)
-Cross-channel messaging — send messages to ANY connected channel (Telegram, Slack, Discord, etc.)
-
-#### Telegram
-  oc-tool message send '{"channel":"telegram","target":"telegram:<USER_ID>","message":"..."}'
-  oc-tool message send '{"channel":"telegram","target":"telegram:<USER_ID>","message":"...","replyToId":"<MSG_ID>"}'
-  oc-tool message read '{"channel":"telegram","target":"telegram:<CHAT_ID>","limit":10}'
-  oc-tool message edit '{"channel":"telegram","target":"telegram:<CHAT_ID>","messageId":"<ID>","message":"new text"}'
-  oc-tool message react '{"channel":"telegram","target":"telegram:<CHAT_ID>","messageId":"<ID>","emoji":"👍"}'
-  oc-tool message pin '{"channel":"telegram","target":"telegram:<CHAT_ID>","messageId":"<ID>"}'
-
-#### Slack
-  oc-tool message send '{"channel":"slack","target":"<USER_ID>","message":"..."}'        # DM by Slack user ID (e.g. U0271DRQN3Z)
-  oc-tool message send '{"channel":"slack","target":"channel:<CHANNEL_ID>","message":"..."}'  # send to channel
-  oc-tool message send '{"channel":"slack","target":"channel:<CHANNEL_ID>","message":"...","replyToId":"<MSG_TS>"}'  # thread reply
-  oc-tool message read '{"channel":"slack","target":"channel:<CHANNEL_ID>","limit":10}'
-  oc-tool message edit '{"channel":"slack","target":"channel:<CHANNEL_ID>","messageId":"<MSG_TS>","message":"new text"}'
-  oc-tool message react '{"channel":"slack","target":"channel:<CHANNEL_ID>","messageId":"<MSG_TS>","emoji":"thumbsup"}'
-  oc-tool message pin '{"channel":"slack","target":"channel:<CHANNEL_ID>","messageId":"<MSG_TS>"}'
-Slack notes:
-- target for read/edit/react/pin MUST be "channel:<channelId>" (e.g. "channel:D0AFMGWT3AM") — "#channel-name" does NOT work
-- Slack message IDs are timestamps like "1772450629.016149" (ts field from read output)
-- Slack emoji names are text slugs without colons: "thumbsup", "white_check_mark", etc. (NOT emoji characters)
-- Use send to user ID to get the channelId back, then use that channelId for subsequent read/react/edit/pin
-
-#### Discord
-  oc-tool message send '{"channel":"discord","target":"channel:<CHANNEL_ID>","message":"..."}'
-  oc-tool message send '{"channel":"discord","target":"user:<USER_ID>","message":"..."}'   # DM
-  oc-tool message send '{"channel":"discord","target":"channel:<CHANNEL_ID>","message":"...","replyToId":"<MSG_ID>"}'
-  oc-tool message read '{"channel":"discord","target":"channel:<CHANNEL_ID>","limit":10}'
-  oc-tool message edit '{"channel":"discord","target":"channel:<CHANNEL_ID>","messageId":"<MSG_ID>","message":"new text"}'
-  oc-tool message react '{"channel":"discord","target":"channel:<CHANNEL_ID>","messageId":"<MSG_ID>","emoji":"👍"}'
-  oc-tool message pin '{"channel":"discord","target":"channel:<CHANNEL_ID>","messageId":"<MSG_ID>"}'
-Discord target formats: "channel:<id>" for channels/threads, "user:<id>" for DMs
-
-Cross-channel example (send from current channel to another):
-  oc-tool message send '{"channel":"slack","target":"<USER_ID>","message":"Hello from Discord!"}'
-
-### Sessions
-  oc-tool sessions_list                              # list active sessions
-  oc-tool sessions_history '{"sessionKey":"...","limit":N}'  # get conversation history
-  oc-tool session_status '{"sessionKey":"..."}'      # check session state
-
-### TTS (Text-to-Speech)
-  oc-tool tts speak '{"text":"..."}'                 # generate voice audio (returns MEDIA: path)
-
-### Web
-  oc-tool web_search '{"query":"..."}'               # search the web
-  oc-tool web_fetch '{"url":"..."}'                  # fetch web page content
-
-### Image Analysis
-  oc-tool image '{"url":"file:///path/to/image.png","prompt":"describe this image"}'
+Browser tip: always run \`oc-tool browser snapshot --interactive\` first to get
+element refs (like e6, e12) before clicking/typing — never guess them.
 
 ## Sending Files and Media (CRITICAL)
 To send ANY file (PDF, image, audio, etc.) to the user, you MUST include a MEDIA: line in your response.

--- a/dist/adapter/openai-to-cli.js
+++ b/dist/adapter/openai-to-cli.js
@@ -434,71 +434,135 @@ export function extractSystemPrompt(messages, tools) {
  *   tool role messages (tool results) are rendered as [Tool Result:] blocks.
  *   When false, both are skipped (CLI handles tools internally).
  */
+/**
+ * Default soft cap on the rendered prompt size, in UTF-8 bytes. The proxy
+ * pipes the prompt via stdin so we are not bound by ARG_MAX (~128 KiB) any
+ * more, but very long histories still cost input tokens linearly *and*
+ * compound across every request because the gateway resends the full
+ * history each turn. Cap conservatively and let the user override.
+ */
+const DEFAULT_PROMPT_BUDGET_BYTES = 100_000;
+const PROMPT_BUDGET_BYTES = (() => {
+    const raw = process.env.CLAUDE_PROXY_PROMPT_BUDGET_BYTES;
+    if (!raw)
+        return DEFAULT_PROMPT_BUDGET_BYTES;
+    const parsed = parseInt(raw, 10);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_PROMPT_BUDGET_BYTES;
+})();
+const TRUNCATION_NOTE = "[earlier messages truncated due to length]";
+/**
+ * Render a single non-system message into its prompt-block string, or
+ * return null if the message has nothing to contribute (NO_REPLY filler,
+ * empty assistant tool_calls, ignored tool results, etc.).
+ */
+function renderMessage(msg, hasExternalTools) {
+    const text = extractText(msg.content);
+    switch (msg.role) {
+        case "user":
+            return `[User]\n${text}`;
+        case "assistant": {
+            // Skip NO_REPLY responses — OpenClaw silent tokens, not real content
+            if (!text || text.trim() === "NO_REPLY") {
+                if (hasExternalTools && msg.tool_calls && msg.tool_calls.length > 0) {
+                    // fall through to tool-call rendering below
+                }
+                else {
+                    return null;
+                }
+            }
+            if (hasExternalTools && msg.tool_calls && msg.tool_calls.length > 0) {
+                // Render prior tool calls as text markers so the model understands
+                // what it previously requested (multi-turn tool conversation)
+                const markers = msg.tool_calls
+                    .map((tc) => {
+                    const args = typeof tc.function.arguments === "string"
+                        ? tc.function.arguments
+                        : JSON.stringify(tc.function.arguments);
+                    let argsObj;
+                    try {
+                        argsObj = JSON.parse(args);
+                    }
+                    catch {
+                        argsObj = args;
+                    }
+                    return `<tool_call>${JSON.stringify({
+                        id: tc.id,
+                        name: tc.function.name,
+                        arguments: argsObj,
+                    })}</tool_call>`;
+                })
+                    .join("\n");
+                return `[Assistant]\n${markers}`;
+            }
+            // Skip assistant messages that are purely tool_calls with no text
+            if (msg.tool_calls && !text)
+                return null;
+            // Clean XML tool patterns to prevent CLI from mimicking them
+            const cleaned = cleanAssistantContent(text);
+            return cleaned ? `[Assistant]\n${cleaned}` : null;
+        }
+        case "tool": {
+            if (!hasExternalTools)
+                return null;
+            const label = msg.tool_call_id
+                ? `Tool Result: ${msg.tool_call_id}${msg.name ? ` (${msg.name})` : ""}`
+                : `Tool Result`;
+            return `[${label}]\n${text}`;
+        }
+        default:
+            return text || null;
+    }
+}
+/**
+ * Convert OpenAI messages array to a single prompt string for Claude CLI.
+ *
+ * Claude Code CLI in --print mode expects a single prompt, not a conversation.
+ * System messages are extracted separately (see extractSystemPrompt). XML tool
+ * patterns in assistant messages are cleaned by cleanAssistantContent() to
+ * prevent the model from mimicking XML format instead of using native tools.
+ * NO_REPLY assistant messages are filtered out (OpenClaw silent reply tokens).
+ *
+ * If the rendered prompt exceeds PROMPT_BUDGET_BYTES, the oldest messages
+ * are dropped (the most recent message is always retained) and a truncation
+ * marker is prepended.
+ *
+ * @param hasExternalTools - When true, assistant messages with tool_calls are
+ *   rendered as <tool_call> markers (for multi-turn tool conversations), and
+ *   tool role messages (tool results) are rendered as [Tool Result:] blocks.
+ *   When false, both are skipped (CLI handles tools internally).
+ */
 export function messagesToPrompt(messages, hasExternalTools = false) {
     const nonSystemMessages = messages.filter((msg) => msg.role !== "system");
     const parts = [];
     for (const msg of nonSystemMessages) {
-        const text = extractText(msg.content);
-        switch (msg.role) {
-            case "user":
-                parts.push(`[User]\n${text}`);
-                break;
-            case "assistant": {
-                // Skip NO_REPLY responses — OpenClaw silent tokens, not real content
-                if (!text || text.trim() === "NO_REPLY")
-                    break;
-                if (hasExternalTools && msg.tool_calls && msg.tool_calls.length > 0) {
-                    // Render prior tool calls as text markers so the model understands
-                    // what it previously requested (multi-turn tool conversation)
-                    const markers = msg.tool_calls
-                        .map((tc) => {
-                        const args = typeof tc.function.arguments === "string"
-                            ? tc.function.arguments
-                            : JSON.stringify(tc.function.arguments);
-                        let argsObj;
-                        try {
-                            argsObj = JSON.parse(args);
-                        }
-                        catch {
-                            argsObj = args;
-                        }
-                        return `<tool_call>${JSON.stringify({
-                            id: tc.id,
-                            name: tc.function.name,
-                            arguments: argsObj,
-                        })}</tool_call>`;
-                    })
-                        .join("\n");
-                    parts.push(`[Assistant]\n${markers}`);
-                    break;
-                }
-                // Skip assistant messages that are purely tool_calls with no text
-                if (msg.tool_calls && !text)
-                    break;
-                // Clean XML tool patterns to prevent CLI from mimicking them
-                const cleaned = cleanAssistantContent(text);
-                if (cleaned) {
-                    parts.push(`[Assistant]\n${cleaned}`);
-                }
-                break;
-            }
-            case "tool": {
-                if (hasExternalTools) {
-                    // Render tool results so the model receives the outcome
-                    const label = msg.tool_call_id
-                        ? `Tool Result: ${msg.tool_call_id}${msg.name ? ` (${msg.name})` : ""}`
-                        : `Tool Result`;
-                    parts.push(`[${label}]\n${text}`);
-                }
-                // When not using external tools, skip (CLI has its own tool system)
-                break;
-            }
-            default:
-                parts.push(text);
-                break;
-        }
+        const part = renderMessage(msg, hasExternalTools);
+        if (part)
+            parts.push(part);
     }
-    return parts.join("\n\n").trim();
+    if (parts.length === 0)
+        return "";
+    const SEPARATOR = "\n\n";
+    const sepBytes = Buffer.byteLength(SEPARATOR, "utf8");
+    const partBytes = parts.map((p) => Buffer.byteLength(p, "utf8"));
+    let totalBytes = partBytes.reduce((sum, b, i) => sum + b + (i > 0 ? sepBytes : 0), 0);
+    if (totalBytes <= PROMPT_BUDGET_BYTES) {
+        return parts.join(SEPARATOR).trim();
+    }
+    // Over budget — drop the oldest parts one at a time, but always keep
+    // the most recent message (that is the actual user turn the model
+    // needs to answer). Surface the truncation in the prompt itself so the
+    // model knows context was clipped.
+    const truncationBytes = Buffer.byteLength(TRUNCATION_NOTE, "utf8") + sepBytes;
+    let dropFrom = 0;
+    while (dropFrom < parts.length - 1 && totalBytes + truncationBytes > PROMPT_BUDGET_BYTES) {
+        totalBytes -= partBytes[dropFrom] + sepBytes;
+        dropFrom += 1;
+    }
+    if (dropFrom > 0) {
+        console.error(`[messagesToPrompt] Truncated ${dropFrom} oldest message(s) ` +
+            `to fit ${PROMPT_BUDGET_BYTES}-byte budget`);
+    }
+    return [TRUNCATION_NOTE, ...parts.slice(dropFrom)].join(SEPARATOR).trim();
 }
 // ─── Stop-sequence bleed stripping ────────────────────────────────
 /**

--- a/dist/adapter/openai-to-cli.test.d.ts
+++ b/dist/adapter/openai-to-cli.test.d.ts
@@ -1,0 +1,2 @@
+export {};
+//# sourceMappingURL=openai-to-cli.test.d.ts.map

--- a/dist/adapter/openai-to-cli.test.js
+++ b/dist/adapter/openai-to-cli.test.js
@@ -1,0 +1,98 @@
+/**
+ * Unit tests for the OpenAI → Claude CLI adapter pure functions.
+ * Run with: npm test
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { extractModel, messagesToPrompt, stripAssistantBleed, } from "./openai-to-cli.js";
+// ── extractModel ───────────────────────────────────────────────────
+test("extractModel: bare aliases pass through", () => {
+    assert.equal(extractModel("opus"), "opus");
+    assert.equal(extractModel("sonnet"), "sonnet");
+    assert.equal(extractModel("haiku"), "haiku");
+});
+test("extractModel: provider prefix is stripped before lookup", () => {
+    assert.equal(extractModel("maxproxy/claude-opus-4"), "opus");
+    assert.equal(extractModel("claude-code-cli/claude-sonnet-4-6"), "sonnet");
+});
+test("extractModel: opus minor versions resolve to dated names", () => {
+    assert.equal(extractModel("claude-opus-4-5"), "claude-opus-4-5-20251101");
+    assert.equal(extractModel("claude-opus-4-1"), "claude-opus-4-1-20250805");
+    assert.equal(extractModel("claude-opus-4-0"), "claude-opus-4-20250514");
+});
+test("extractModel: sonnet variants collapse to alias", () => {
+    assert.equal(extractModel("claude-sonnet-4"), "sonnet");
+    assert.equal(extractModel("claude-sonnet-4-5"), "sonnet");
+});
+test("extractModel: empty / unknown defaults to opus", () => {
+    assert.equal(extractModel(""), "opus");
+    assert.equal(extractModel("gpt-4o"), "opus");
+});
+// ── stripAssistantBleed ────────────────────────────────────────────
+test("stripAssistantBleed: cuts at first \\n[User] sentinel", () => {
+    const input = "Here is the answer.\n[User]\nNext turn?";
+    assert.equal(stripAssistantBleed(input), "Here is the answer.");
+});
+test("stripAssistantBleed: handles \\nHuman: legacy format", () => {
+    const input = "Done.\nHuman: another question";
+    assert.equal(stripAssistantBleed(input), "Done.");
+});
+test("stripAssistantBleed: leaves clean text untouched", () => {
+    const input = "Just a normal reply with no sentinels.";
+    assert.equal(stripAssistantBleed(input), input);
+});
+test("stripAssistantBleed: cuts at the earliest sentinel when multiple appear", () => {
+    const input = "ok\nHuman: q1\n[User]\nq2";
+    assert.equal(stripAssistantBleed(input), "ok");
+});
+// ── messagesToPrompt ───────────────────────────────────────────────
+test("messagesToPrompt: renders user/assistant turns with [User]/[Assistant] tags", () => {
+    const prompt = messagesToPrompt([
+        { role: "user", content: "Hello" },
+        { role: "assistant", content: "Hi there" },
+        { role: "user", content: "Why?" },
+    ]);
+    assert.match(prompt, /\[User\]\nHello/);
+    assert.match(prompt, /\[Assistant\]\nHi there/);
+    assert.match(prompt, /\[User\]\nWhy\?$/);
+});
+test("messagesToPrompt: drops NO_REPLY assistant messages", () => {
+    const prompt = messagesToPrompt([
+        { role: "user", content: "ping" },
+        { role: "assistant", content: "NO_REPLY" },
+        { role: "user", content: "are you there?" },
+    ]);
+    assert.doesNotMatch(prompt, /NO_REPLY/);
+    assert.match(prompt, /are you there\?/);
+});
+test("messagesToPrompt: array content of {type:'text'} blocks is flattened", () => {
+    const prompt = messagesToPrompt([
+        {
+            role: "user",
+            content: [
+                { type: "text", text: "first" },
+                { type: "text", text: "second" },
+            ],
+        },
+    ]);
+    assert.match(prompt, /\[User\]\nfirst\nsecond/);
+});
+test("messagesToPrompt: truncates oldest history when over byte budget", () => {
+    // Force the smallest possible budget for this test by overriding the env
+    // var BEFORE re-importing? We can't easily do that with a static import.
+    // Instead, build a 200 KiB conversation and assume the default 100 KiB
+    // budget kicks in.
+    const big = "x".repeat(20_000);
+    const messages = Array.from({ length: 8 }, (_, i) => ({
+        role: "user",
+        content: `turn ${i}: ${big}`,
+    }));
+    // Final message we expect to always survive
+    messages.push({ role: "user", content: "FINAL_MARKER" });
+    const prompt = messagesToPrompt(messages);
+    assert.match(prompt, /FINAL_MARKER/);
+    assert.match(prompt, /earlier messages truncated/);
+    // The very first turn (turn 0) should have been dropped
+    assert.doesNotMatch(prompt, /turn 0:/);
+});
+//# sourceMappingURL=openai-to-cli.test.js.map

--- a/dist/server/daemon.d.ts
+++ b/dist/server/daemon.d.ts
@@ -1,0 +1,52 @@
+export declare const PID_FILE: string;
+export declare const LOG_FILE: string;
+export interface DaemonInfo {
+    pid: number;
+    port: number;
+    startedAt: string;
+}
+export declare function readPidFile(): DaemonInfo | null;
+export declare function writePidFile(info: DaemonInfo): void;
+export declare function removePidFile(): void;
+/**
+ * Best-effort liveness check. process.kill(pid, 0) does not deliver a signal,
+ * it just performs the permission/existence check the kernel does normally.
+ */
+export declare function isAlive(pid: number): boolean;
+/**
+ * Return the live daemon described by the pidfile, or null if there is no
+ * daemon (or the pidfile is stale, in which case we also clean it up).
+ */
+export declare function getRunningDaemon(): DaemonInfo | null;
+/**
+ * Re-spawn the standalone entry point as a detached background process.
+ *
+ * The current Node binary and the script path of the running CLI are reused
+ * verbatim so that whichever way the user invoked us (npm link, global
+ * install, npx, …) keeps working without us having to guess.
+ *
+ * The child is started with `--foreground` so it knows NOT to recurse and
+ * to write its own pidfile after the HTTP listener is up. stdout and stderr
+ * are redirected to LOG_FILE in append mode.
+ */
+export declare function daemonize(scriptPath: string, args: string[]): number;
+/**
+ * Wait for the background child to register itself in the pidfile.
+ * Resolves with the daemon info, or rejects after `timeoutMs` if the
+ * child failed to come up (the user should then read LOG_FILE).
+ */
+export declare function waitForPidFile(timeoutMs?: number): Promise<DaemonInfo>;
+/**
+ * SIGTERM the running daemon and wait for it to exit, escalating to SIGKILL
+ * if it does not stop within `timeoutMs`. Cleans up the pidfile in either
+ * case.
+ *
+ * Returns:
+ *   { stopped: true,  pid }  — daemon was running and is now stopped
+ *   { stopped: false, pid: null } — no daemon was running
+ */
+export declare function stopDaemon(timeoutMs?: number): Promise<{
+    stopped: boolean;
+    pid: number | null;
+}>;
+//# sourceMappingURL=daemon.d.ts.map

--- a/dist/server/daemon.js
+++ b/dist/server/daemon.js
@@ -1,0 +1,159 @@
+/**
+ * Background daemon utilities for the standalone server.
+ *
+ * The proxy is a long-lived process that ought to keep running across
+ * terminal sessions, but it does not need a system-level service manager
+ * (systemd / launchd) for the common case. This module gives `claude-max-api`
+ * a built-in `start` / `stop` / `status` lifecycle by re-spawning itself
+ * as a detached child and tracking it with a small pidfile.
+ *
+ * State files live under ~/.claude-max-api/:
+ *   proxy.pid   — JSON: { pid, port, startedAt }
+ *   proxy.log   — combined stdout+stderr from the background process
+ */
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import { spawn } from "node:child_process";
+const STATE_DIR = path.join(os.homedir(), ".claude-max-api");
+export const PID_FILE = path.join(STATE_DIR, "proxy.pid");
+export const LOG_FILE = path.join(STATE_DIR, "proxy.log");
+function ensureStateDir() {
+    fs.mkdirSync(STATE_DIR, { recursive: true });
+}
+export function readPidFile() {
+    try {
+        const raw = fs.readFileSync(PID_FILE, "utf8");
+        const parsed = JSON.parse(raw);
+        if (typeof parsed?.pid === "number" &&
+            typeof parsed?.port === "number" &&
+            typeof parsed?.startedAt === "string") {
+            return parsed;
+        }
+        return null;
+    }
+    catch {
+        return null;
+    }
+}
+export function writePidFile(info) {
+    ensureStateDir();
+    fs.writeFileSync(PID_FILE, JSON.stringify(info, null, 2));
+}
+export function removePidFile() {
+    try {
+        fs.unlinkSync(PID_FILE);
+    }
+    catch {
+        /* ignore — file may have already been removed */
+    }
+}
+/**
+ * Best-effort liveness check. process.kill(pid, 0) does not deliver a signal,
+ * it just performs the permission/existence check the kernel does normally.
+ */
+export function isAlive(pid) {
+    try {
+        process.kill(pid, 0);
+        return true;
+    }
+    catch {
+        return false;
+    }
+}
+/**
+ * Return the live daemon described by the pidfile, or null if there is no
+ * daemon (or the pidfile is stale, in which case we also clean it up).
+ */
+export function getRunningDaemon() {
+    const info = readPidFile();
+    if (!info)
+        return null;
+    if (!isAlive(info.pid)) {
+        removePidFile();
+        return null;
+    }
+    return info;
+}
+/**
+ * Re-spawn the standalone entry point as a detached background process.
+ *
+ * The current Node binary and the script path of the running CLI are reused
+ * verbatim so that whichever way the user invoked us (npm link, global
+ * install, npx, …) keeps working without us having to guess.
+ *
+ * The child is started with `--foreground` so it knows NOT to recurse and
+ * to write its own pidfile after the HTTP listener is up. stdout and stderr
+ * are redirected to LOG_FILE in append mode.
+ */
+export function daemonize(scriptPath, args) {
+    ensureStateDir();
+    const logFd = fs.openSync(LOG_FILE, "a");
+    try {
+        const child = spawn(process.execPath, [scriptPath, "--foreground", ...args], {
+            detached: true,
+            stdio: ["ignore", logFd, logFd],
+            env: process.env,
+        });
+        child.unref();
+        return child.pid ?? -1;
+    }
+    finally {
+        fs.closeSync(logFd);
+    }
+}
+/**
+ * Wait for the background child to register itself in the pidfile.
+ * Resolves with the daemon info, or rejects after `timeoutMs` if the
+ * child failed to come up (the user should then read LOG_FILE).
+ */
+export async function waitForPidFile(timeoutMs = 8_000) {
+    const start = Date.now();
+    while (Date.now() - start < timeoutMs) {
+        const info = readPidFile();
+        if (info && isAlive(info.pid))
+            return info;
+        await new Promise((r) => setTimeout(r, 100));
+    }
+    throw new Error(`Background process did not register within ${timeoutMs}ms. Check ${LOG_FILE} for startup errors.`);
+}
+/**
+ * SIGTERM the running daemon and wait for it to exit, escalating to SIGKILL
+ * if it does not stop within `timeoutMs`. Cleans up the pidfile in either
+ * case.
+ *
+ * Returns:
+ *   { stopped: true,  pid }  — daemon was running and is now stopped
+ *   { stopped: false, pid: null } — no daemon was running
+ */
+export async function stopDaemon(timeoutMs = 10_000) {
+    const info = getRunningDaemon();
+    if (!info)
+        return { stopped: false, pid: null };
+    try {
+        process.kill(info.pid, "SIGTERM");
+    }
+    catch {
+        // Process is already gone — clean up and report success.
+        removePidFile();
+        return { stopped: true, pid: info.pid };
+    }
+    const start = Date.now();
+    while (Date.now() - start < timeoutMs) {
+        if (!isAlive(info.pid)) {
+            removePidFile();
+            return { stopped: true, pid: info.pid };
+        }
+        await new Promise((r) => setTimeout(r, 100));
+    }
+    // Did not exit within timeout — escalate.
+    try {
+        process.kill(info.pid, "SIGKILL");
+    }
+    catch {
+        /* ignore */
+    }
+    removePidFile();
+    return { stopped: true, pid: info.pid };
+}
+//# sourceMappingURL=daemon.js.map

--- a/dist/server/index.js
+++ b/dist/server/index.js
@@ -5,7 +5,7 @@
  */
 import express from "express";
 import { createServer } from "http";
-import { handleChatCompletions, handleModels, handleHealth } from "./routes.js";
+import { handleChatCompletions, handleModels, handleHealth, handleRequests } from "./routes.js";
 let serverInstance = null;
 /**
  * Create and configure the Express app
@@ -48,6 +48,7 @@ function createApp() {
     // Routes
     app.get("/health", handleHealth);
     app.get("/v1/models", handleModels);
+    app.get("/v1/requests", handleRequests);
     app.post("/v1/chat/completions", handleChatCompletions);
     // 404 handler
     app.use((_req, res) => {

--- a/dist/server/index.js
+++ b/dist/server/index.js
@@ -21,9 +21,22 @@ function createApp() {
         }
         next();
     });
-    // CORS headers for local development
-    app.use((_req, res, next) => {
-        res.setHeader("Access-Control-Allow-Origin", "*");
+    // CORS headers. The proxy listens on 127.0.0.1 by default, so the only
+    // legitimate browser callers are pages served from localhost. We mirror
+    // an Origin header back if it looks local; cross-origin requests get no
+    // ACAO header at all (browser will block them). Set CLAUDE_PROXY_ALLOW_CORS_ANY=1
+    // for the legacy "*" behavior if a deployment depends on it.
+    const allowAnyOrigin = process.env.CLAUDE_PROXY_ALLOW_CORS_ANY === "1";
+    const LOCAL_ORIGIN_RE = /^https?:\/\/(?:localhost|127\.0\.0\.1|\[::1\])(?::\d+)?$/;
+    app.use((req, res, next) => {
+        const origin = req.headers.origin;
+        if (allowAnyOrigin) {
+            res.setHeader("Access-Control-Allow-Origin", "*");
+        }
+        else if (typeof origin === "string" && LOCAL_ORIGIN_RE.test(origin)) {
+            res.setHeader("Access-Control-Allow-Origin", origin);
+            res.setHeader("Vary", "Origin");
+        }
         res.setHeader("Access-Control-Allow-Methods", "GET, POST, OPTIONS");
         res.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization");
         next();

--- a/dist/server/install-service.d.ts
+++ b/dist/server/install-service.d.ts
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+export {};
+//# sourceMappingURL=install-service.d.ts.map

--- a/dist/server/install-service.js
+++ b/dist/server/install-service.js
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+/**
+ * Post-install hook + manual `install-service` entry point.
+ *
+ * Invocation patterns:
+ *   node install-service.js --auto   # quiet postinstall from package.json
+ *   node install-service.js          # interactive-style manual install
+ *   node install-service.js <port>   # manual install on a specific port
+ *
+ * In --auto mode we bail out silently on any non-fatal condition (local
+ * install, running as root, unsupported platform) so a failed postinstall
+ * never blocks `npm install`. In manual mode we surface the real error.
+ */
+import { detectPlatform, installService, isInstalled } from "./service.js";
+const DEFAULT_PORT = 3456;
+function parsePort(arg) {
+    if (!arg)
+        return DEFAULT_PORT;
+    const n = parseInt(arg, 10);
+    if (!Number.isFinite(n) || n < 1 || n > 65535) {
+        throw new Error(`Invalid port: ${arg}`);
+    }
+    return n;
+}
+function main() {
+    const auto = process.argv.includes("--auto");
+    const positional = process.argv.slice(2).filter((a) => !a.startsWith("--"));
+    const port = parsePort(positional[0]);
+    // Skip postinstall for local installs. Only register the service when
+    // the user has actually done `npm install -g`. Otherwise every
+    // `npm install` in the checkout (including CI) would mess with their
+    // login services.
+    if (auto && process.env.npm_config_global !== "true") {
+        return;
+    }
+    // Refuse to install as root. `sudo npm install -g` is common on Linux,
+    // but a user-level service installed by root would live under /root and
+    // never auto-start for the actual user. Skip silently in --auto mode so
+    // we don't explode the install, and print a friendly note.
+    if ((process.getuid?.() ?? 0) === 0) {
+        if (!auto) {
+            console.error("Refusing to install service as root. Re-run without sudo:\n" +
+                "  claude-max-api install-service");
+            process.exit(1);
+        }
+        const sudoUser = process.env.SUDO_USER;
+        console.error(`[claude-max-api] Skipping auto service install (running as root${sudoUser ? `, invoked by ${sudoUser}` : ""}).`);
+        console.error("[claude-max-api] To enable auto-start on login, run as your normal user:");
+        console.error("  claude-max-api install-service");
+        return;
+    }
+    const platform = detectPlatform();
+    if (!platform) {
+        if (auto)
+            return;
+        console.error(`No supported service backend on ${process.platform}. Use 'claude-max-api start' for the built-in daemon fallback.`);
+        process.exit(1);
+    }
+    try {
+        const wasInstalled = isInstalled();
+        installService(port);
+        if (auto) {
+            console.log(`[claude-max-api] Service ${wasInstalled ? "updated" : "installed"} (${platform}) and set to auto-start on login.`);
+            console.log(`[claude-max-api] Manage with: claude-max-api {status,stop,restart,logs,uninstall-service}`);
+        }
+        else {
+            console.log(`Service ${wasInstalled ? "updated" : "installed"} on ${platform}, listening on port ${port}.`);
+            console.log("It will start automatically on login.");
+        }
+    }
+    catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        if (auto) {
+            // Never fail the install. The user can re-run install-service
+            // manually once they've fixed whatever went wrong.
+            console.error(`[claude-max-api] Auto service install skipped: ${message}`);
+            console.error("[claude-max-api] Re-run manually with: claude-max-api install-service");
+            return;
+        }
+        console.error(`Failed to install service: ${message}`);
+        process.exit(1);
+    }
+}
+try {
+    main();
+}
+catch (err) {
+    if (process.argv.includes("--auto")) {
+        // Last-ditch guard: don't ever break npm install on our account.
+        console.error("[claude-max-api] Post-install hook failed:", err instanceof Error ? err.message : err);
+        process.exit(0);
+    }
+    throw err;
+}
+//# sourceMappingURL=install-service.js.map

--- a/dist/server/request-tracker.d.ts
+++ b/dist/server/request-tracker.d.ts
@@ -1,0 +1,47 @@
+/**
+ * In-memory request tracker for the monitor endpoint.
+ *
+ * Keeps a circular buffer of recent request entries so the `mon` CLI
+ * command can poll `/v1/requests` and display live status.
+ */
+export type RequestStatus = "in progress" | "completed" | "error";
+export interface RequestEntry {
+    id: string;
+    inputLength: number;
+    status: RequestStatus;
+    outputLength: number;
+    startedAt: number;
+    completedAt: number | null;
+}
+/** Serialized form returned by the API (adds computed elapsedMs). */
+export interface RequestEntryJSON {
+    id: string;
+    inputLength: number;
+    status: RequestStatus;
+    outputLength: number;
+    startedAt: string;
+    elapsedMs: number;
+}
+/**
+ * Register a new in-flight request.
+ */
+export declare function trackRequest(id: string, inputLength: number): void;
+/**
+ * Update an existing tracked request (e.g. on completion or error).
+ * Silently no-ops if the id is not found (already evicted).
+ */
+export declare function updateRequest(id: string, patch: Partial<Pick<RequestEntry, "status" | "outputLength">>): void;
+/**
+ * Increment the output length for an in-flight request.
+ */
+export declare function addOutputBytes(id: string, bytes: number): void;
+/**
+ * Return the most recent `n` entries (newest first).
+ * Pass -1 or omit to return all.
+ */
+export declare function getRequests(n?: number): RequestEntryJSON[];
+/**
+ * Return the number of currently in-progress requests.
+ */
+export declare function getActiveCount(): number;
+//# sourceMappingURL=request-tracker.d.ts.map

--- a/dist/server/request-tracker.js
+++ b/dist/server/request-tracker.js
@@ -1,0 +1,76 @@
+/**
+ * In-memory request tracker for the monitor endpoint.
+ *
+ * Keeps a circular buffer of recent request entries so the `mon` CLI
+ * command can poll `/v1/requests` and display live status.
+ */
+const MAX_ENTRIES = 200;
+// Ordered oldest → newest.
+const entries = [];
+/**
+ * Register a new in-flight request.
+ */
+export function trackRequest(id, inputLength) {
+    if (entries.length >= MAX_ENTRIES) {
+        entries.shift();
+    }
+    entries.push({
+        id,
+        inputLength,
+        status: "in progress",
+        outputLength: 0,
+        startedAt: Date.now(),
+        completedAt: null,
+    });
+}
+/**
+ * Update an existing tracked request (e.g. on completion or error).
+ * Silently no-ops if the id is not found (already evicted).
+ */
+export function updateRequest(id, patch) {
+    const entry = entries.find((e) => e.id === id);
+    if (!entry)
+        return;
+    if (patch.status !== undefined) {
+        entry.status = patch.status;
+        if (patch.status === "completed" || patch.status === "error") {
+            entry.completedAt = Date.now();
+        }
+    }
+    if (patch.outputLength !== undefined) {
+        entry.outputLength = patch.outputLength;
+    }
+}
+/**
+ * Increment the output length for an in-flight request.
+ */
+export function addOutputBytes(id, bytes) {
+    const entry = entries.find((e) => e.id === id);
+    if (entry)
+        entry.outputLength += bytes;
+}
+/**
+ * Return the most recent `n` entries (newest first).
+ * Pass -1 or omit to return all.
+ */
+export function getRequests(n) {
+    const now = Date.now();
+    // Copy and reverse so newest is first.
+    const reversed = [...entries].reverse();
+    const slice = n != null && n > 0 ? reversed.slice(0, n) : reversed;
+    return slice.map((e) => ({
+        id: e.id,
+        inputLength: e.inputLength,
+        status: e.status,
+        outputLength: e.outputLength,
+        startedAt: new Date(e.startedAt).toISOString(),
+        elapsedMs: (e.completedAt ?? now) - e.startedAt,
+    }));
+}
+/**
+ * Return the number of currently in-progress requests.
+ */
+export function getActiveCount() {
+    return entries.filter((e) => e.status === "in progress").length;
+}
+//# sourceMappingURL=request-tracker.js.map

--- a/dist/server/routes.d.ts
+++ b/dist/server/routes.d.ts
@@ -19,4 +19,8 @@ export declare function handleModels(_req: Request, res: Response): void;
  * Handle GET /health — Health check endpoint
  */
 export declare function handleHealth(_req: Request, res: Response): void;
+/**
+ * Handle GET /v1/requests — Returns recent request status for the monitor
+ */
+export declare function handleRequests(req: Request, res: Response): void;
 //# sourceMappingURL=routes.d.ts.map

--- a/dist/server/routes.js
+++ b/dist/server/routes.js
@@ -221,14 +221,13 @@ async function handleStreamingResponse(req, res, subprocess, cliInput, requestId
                 const { hasToolCalls, toolCalls, textWithoutToolCalls } = parseToolCalls(safeText);
                 if (!res.writableEnded) {
                     if (hasToolCalls) {
-                        // Emit synthesized tool call SSE chunks
+                        // Emit synthesized tool call SSE chunks. The chunks
+                        // already include a finish_reason:"tool_calls" terminator,
+                        // so we only need a single [DONE] sentinel after them.
                         const chunks = createToolCallChunks(toolCalls, requestId, lastModel);
                         for (const chunk of chunks) {
                             res.write(`data: ${JSON.stringify(chunk)}\n\n`);
                         }
-                        // Use [DONE] as the sole end signal for tool call responses
-                        // (tool call chunks already have finish_reason:"tool_calls")
-                        res.write("data: [DONE]\n\n");
                     }
                     else {
                         // No tool calls — emit full text as a single content chunk

--- a/dist/server/routes.js
+++ b/dist/server/routes.js
@@ -95,12 +95,11 @@ async function handleStreamingResponse(req, res, subprocess, cliInput, requestId
         let isFirst = false; // role:"assistant" already sent in the announce chunk above
         let allContent = ""; // Track all content for auth error detection
         // ── Bleed detection state ──────────────────────────────────
-        // We accumulate streamed text to detect [User]/[Human] bleed patterns.
-        // Once a bleed sentinel is detected, we stop forwarding further deltas.
-        let accumulated = "";
-        let totalFlushed = 0;
+        // We hold back a small tail buffer (MAX_SENTINEL_LEN bytes) so a
+        // bleed sentinel that straddles two delta chunks is still caught,
+        // without rescanning the entire response on every delta.
+        let tail = "";
         let bleedDetected = false;
-        // Longest sentinel we watch for, so we know how much tail to hold back
         const BLEED_SENTINELS = ["\n[User]", "\n[Human]", "\nHuman:"];
         const MAX_SENTINEL_LEN = Math.max(...BLEED_SENTINELS.map((s) => s.length));
         /**
@@ -128,32 +127,42 @@ async function handleStreamingResponse(req, res, subprocess, cliInput, requestId
         }
         /**
          * Process an incoming delta with bleed detection.
-         * We keep a tail buffer (MAX_SENTINEL_LEN chars) unwritten until we're
-         * sure it doesn't start a bleed pattern — this prevents partial sentinels
-         * (split across two deltas) from leaking through.
+         * Keeps a tail buffer (MAX_SENTINEL_LEN chars) unwritten until the
+         * next delta arrives so a sentinel split across two deltas is still
+         * caught, while running in O(incoming.length + MAX_SENTINEL_LEN) per
+         * call instead of rescanning the full accumulated response each time.
          */
         function processDelta(incoming) {
-            if (bleedDetected || res.writableEnded)
+            if (bleedDetected || res.writableEnded || !incoming)
                 return;
-            accumulated += incoming;
-            // Check if the accumulated text contains a bleed sentinel
-            const safe = stripAssistantBleed(accumulated);
-            if (safe.length < accumulated.length) {
-                // Bleed found — write only the unflushed safe portion and stop
+            const buf = tail + incoming;
+            // Search only the (small) tail+incoming window for sentinels.
+            // The earlier flushed prefix has already been cleared by previous
+            // calls, so any sentinel must lie within this window.
+            let cutAt = -1;
+            for (const sentinel of BLEED_SENTINELS) {
+                const idx = buf.indexOf(sentinel);
+                if (idx !== -1 && (cutAt === -1 || idx < cutAt)) {
+                    cutAt = idx;
+                }
+            }
+            if (cutAt !== -1) {
                 bleedDetected = true;
-                const safeNew = safe.slice(totalFlushed);
-                if (safeNew)
-                    writeDelta(safeNew);
+                const safe = buf.slice(0, cutAt);
+                if (safe)
+                    writeDelta(safe);
+                tail = "";
                 console.error("[Stream] Bleed detected — halting delta stream");
                 return;
             }
-            // No bleed yet, but hold back the last MAX_SENTINEL_LEN chars as a
-            // look-ahead buffer in case a sentinel straddles two delta chunks.
-            const safeLen = Math.max(0, accumulated.length - MAX_SENTINEL_LEN);
-            const toFlush = safeLen - totalFlushed;
-            if (toFlush > 0) {
-                writeDelta(accumulated.slice(totalFlushed, totalFlushed + toFlush));
-                totalFlushed += toFlush;
+            // Hold back the last MAX_SENTINEL_LEN chars as a look-ahead buffer.
+            if (buf.length > MAX_SENTINEL_LEN) {
+                const flushUntil = buf.length - MAX_SENTINEL_LEN;
+                writeDelta(buf.slice(0, flushUntil));
+                tail = buf.slice(flushUntil);
+            }
+            else {
+                tail = buf;
             }
         }
         /**
@@ -161,12 +170,12 @@ async function handleStreamingResponse(req, res, subprocess, cliInput, requestId
          * Run through stripAssistantBleed one more time for safety.
          */
         function flushTail() {
-            if (bleedDetected || res.writableEnded)
+            if (bleedDetected || res.writableEnded || !tail)
                 return;
-            const safe = stripAssistantBleed(accumulated);
-            const remaining = safe.slice(totalFlushed);
-            if (remaining)
-                writeDelta(remaining);
+            const safe = stripAssistantBleed(tail);
+            if (safe)
+                writeDelta(safe);
+            tail = "";
         }
         // ──────────────────────────────────────────────────────────
         // Handle client disconnect

--- a/dist/server/routes.js
+++ b/dist/server/routes.js
@@ -8,6 +8,20 @@ function isAuthError(text) {
     const lower = text.toLowerCase();
     return AUTH_ERROR_PATTERNS.some((p) => lower.includes(p));
 }
+// ── Concurrency Limit ──────────────────────────────────────────────
+// Each in-flight chat request spawns a Claude CLI subprocess, which is
+// expensive (hundreds of MB of RAM each). Cap concurrency to avoid
+// OOM-killing the box on a burst of requests. Excess requests get a
+// 429 with Retry-After so well-behaved clients back off cleanly.
+const DEFAULT_MAX_CONCURRENT = 4;
+const MAX_CONCURRENT = (() => {
+    const raw = process.env.CLAUDE_PROXY_MAX_CONCURRENT;
+    if (!raw)
+        return DEFAULT_MAX_CONCURRENT;
+    const parsed = parseInt(raw, 10);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_MAX_CONCURRENT;
+})();
+let activeRequests = 0;
 // ── Route Handlers ─────────────────────────────────────────────────
 /**
  * Handle POST /v1/chat/completions
@@ -18,6 +32,22 @@ export async function handleChatCompletions(req, res) {
     const requestId = uuidv4().replace(/-/g, "").slice(0, 24);
     const body = req.body;
     const stream = body.stream === true;
+    // Reject early if we are already at the configured concurrency cap.
+    // Each handler spawns a separate Claude CLI subprocess (~200+ MB RSS),
+    // so unbounded concurrency will OOM the box on a burst.
+    if (activeRequests >= MAX_CONCURRENT) {
+        console.error(`[handleChatCompletions] Rejecting request — at concurrency limit ${activeRequests}/${MAX_CONCURRENT}`);
+        res.setHeader("Retry-After", "5");
+        res.status(429).json({
+            error: {
+                message: `Too many concurrent requests (limit ${MAX_CONCURRENT}). Retry shortly.`,
+                type: "rate_limit_error",
+                code: "concurrency_limit",
+            },
+        });
+        return;
+    }
+    activeRequests += 1;
     try {
         // Validate request
         if (!body.messages || !Array.isArray(body.messages) || body.messages.length === 0) {
@@ -75,6 +105,9 @@ export async function handleChatCompletions(req, res) {
                 console.error("[handleChatCompletions] Failed to write SSE error fallback:", writeErr);
             }
         }
+    }
+    finally {
+        activeRequests -= 1;
     }
 }
 /**

--- a/dist/server/routes.js
+++ b/dist/server/routes.js
@@ -385,50 +385,67 @@ async function handleStreamingResponse(res, subprocess, cliInput, requestId, sub
 async function handleNonStreamingResponse(res, subprocess, cliInput, requestId, subOpts) {
     return new Promise((resolve) => {
         let finalResult = null;
+        // Each call to subprocess events fires from independent emitters,
+        // so error/close/start can race. The first one to write the response
+        // owns it; everything else must early-return.
+        let responded = false;
+        const respond = (fn) => {
+            if (responded || res.headersSent) {
+                responded = true;
+                return;
+            }
+            responded = true;
+            fn();
+        };
         subprocess.on("result", (result) => {
             finalResult = result;
         });
         subprocess.on("error", (error) => {
             console.error("[NonStreaming] Error:", error.message);
-            res.status(500).json({
-                error: { message: error.message, type: "server_error", code: null },
+            respond(() => {
+                res.status(500).json({
+                    error: { message: error.message, type: "server_error", code: null },
+                });
             });
             resolve();
         });
         subprocess.on("close", (code) => {
-            if (finalResult) {
-                const resultText = finalResult.result ?? "";
-                // Detect auth errors
-                if (isAuthError(resultText)) {
-                    console.error("[NonStreaming] Auth error detected in CLI output");
-                    res.status(503).json({
-                        error: { message: "Claude CLI is not authenticated. Run: claude login", type: "auth_error", code: "not_authenticated" },
-                    });
-                    resolve();
-                    return;
+            respond(() => {
+                if (finalResult) {
+                    const resultText = finalResult.result ?? "";
+                    // Detect auth errors
+                    if (isAuthError(resultText)) {
+                        console.error("[NonStreaming] Auth error detected in CLI output");
+                        res.status(503).json({
+                            error: { message: "Claude CLI is not authenticated. Run: claude login", type: "auth_error", code: "not_authenticated" },
+                        });
+                        return;
+                    }
+                    // Strip any [User]/[Human] bleed from the final result text
+                    finalResult = {
+                        ...finalResult,
+                        result: stripAssistantBleed(resultText),
+                    };
+                    res.json(cliResultToOpenai(finalResult, requestId));
                 }
-                // Strip any [User]/[Human] bleed from the final result text
-                finalResult = {
-                    ...finalResult,
-                    result: stripAssistantBleed(resultText),
-                };
-                res.json(cliResultToOpenai(finalResult, requestId));
-            }
-            else if (!res.headersSent) {
-                res.status(500).json({
-                    error: {
-                        message: `Claude CLI exited with code ${code} without response`,
-                        type: "server_error",
-                        code: null,
-                    },
-                });
-            }
+                else {
+                    res.status(500).json({
+                        error: {
+                            message: `Claude CLI exited with code ${code} without response`,
+                            type: "server_error",
+                            code: null,
+                        },
+                    });
+                }
+            });
             resolve();
         });
         // Start the subprocess with session-aware options
         subprocess.start(cliInput.prompt, subOpts).catch((error) => {
-            res.status(500).json({
-                error: { message: error.message, type: "server_error", code: null },
+            respond(() => {
+                res.status(500).json({
+                    error: { message: error.message, type: "server_error", code: null },
+                });
             });
             resolve();
         });

--- a/dist/server/routes.js
+++ b/dist/server/routes.js
@@ -58,6 +58,23 @@ export async function handleChatCompletions(req, res) {
                 error: { message, type: "server_error", code: null },
             });
         }
+        else if (!res.writableEnded) {
+            // Headers were already flushed for SSE (we sent the role-announce
+            // chunk before subprocess.start() ran), so we cannot fall back to
+            // res.status(500).json(). Instead, write a structured error event
+            // followed by [DONE] so streaming clients see a real failure
+            // instead of a silently truncated stream.
+            try {
+                res.write(`data: ${JSON.stringify({
+                    error: { message, type: "server_error", code: null },
+                })}\n\n`);
+                res.write("data: [DONE]\n\n");
+                res.end();
+            }
+            catch (writeErr) {
+                console.error("[handleChatCompletions] Failed to write SSE error fallback:", writeErr);
+            }
+        }
     }
 }
 /**

--- a/dist/server/routes.js
+++ b/dist/server/routes.js
@@ -71,8 +71,11 @@ export async function handleChatCompletions(req, res) {
         const hasTools = Array.isArray(body.tools) &&
             body.tools.length > 0 &&
             body.tool_choice !== "none";
+        // The client-supplied model string is what we echo back in chunks,
+        // not the CLI-mapped value (which may collapse to "opus"/"sonnet").
+        const clientModel = typeof body.model === "string" && body.model ? body.model : "claude-sonnet-4";
         if (stream) {
-            await handleStreamingResponse(res, subprocess, cliInput, requestId, subOpts, hasTools);
+            await handleStreamingResponse(res, subprocess, cliInput, requestId, subOpts, clientModel, hasTools);
         }
         else {
             await handleNonStreamingResponse(res, subprocess, cliInput, requestId, subOpts);
@@ -115,7 +118,7 @@ export async function handleChatCompletions(req, res) {
  *
  * Each content_delta event is immediately written to the response stream.
  */
-async function handleStreamingResponse(res, subprocess, cliInput, requestId, subOpts, hasTools = false) {
+async function handleStreamingResponse(res, subprocess, cliInput, requestId, subOpts, clientModel, hasTools = false) {
     // Set SSE headers
     res.setHeader("Content-Type", "text/event-stream");
     res.setHeader("Cache-Control", "no-cache");
@@ -135,12 +138,15 @@ async function handleStreamingResponse(res, subprocess, cliInput, requestId, sub
         id: `chatcmpl-${requestId}`,
         object: "chat.completion.chunk",
         created: Math.floor(Date.now() / 1000),
-        model: "claude-sonnet-4",
+        model: clientModel,
         choices: [{ index: 0, delta: { role: "assistant" }, finish_reason: null }],
     };
     res.write(`data: ${JSON.stringify(announceChunk)}\n\n`);
     return new Promise((resolve, reject) => {
-        let lastModel = "claude-sonnet-4";
+        // Default to the client-requested model so the very first content
+        // chunks aren't tagged with the wrong family. The CLI will overwrite
+        // this with the real model id once the assistant message arrives.
+        let lastModel = clientModel;
         let isComplete = false;
         // ── Bleed detection state ──────────────────────────────────
         // We hold back a small tail buffer (MAX_SENTINEL_LEN bytes) so a

--- a/dist/server/routes.js
+++ b/dist/server/routes.js
@@ -2,6 +2,7 @@ import { v4 as uuidv4 } from "uuid";
 import { ClaudeSubprocess } from "../subprocess/manager.js";
 import { openaiToCli, stripAssistantBleed } from "../adapter/openai-to-cli.js";
 import { cliResultToOpenai, createDoneChunk, parseToolCalls, createToolCallChunks } from "../adapter/cli-to-openai.js";
+import { trackRequest, updateRequest, addOutputBytes, getRequests, getActiveCount } from "./request-tracker.js";
 // ── Auth Error Detection ────────────────────────────────────────────
 const AUTH_ERROR_PATTERNS = ["not logged in", "please run /login"];
 function isAuthError(text) {
@@ -48,6 +49,8 @@ export async function handleChatCompletions(req, res) {
         return;
     }
     activeRequests += 1;
+    const inputLength = Buffer.byteLength(JSON.stringify(body.messages), "utf8");
+    trackRequest(requestId, inputLength);
     try {
         // Validate request
         if (!body.messages || !Array.isArray(body.messages) || body.messages.length === 0) {
@@ -82,6 +85,7 @@ export async function handleChatCompletions(req, res) {
         }
     }
     catch (error) {
+        updateRequest(requestId, { status: "error" });
         const message = error instanceof Error ? error.message : "Unknown error";
         const stack = error instanceof Error ? error.stack : "";
         console.error("[handleChatCompletions] Error:", message);
@@ -331,12 +335,15 @@ async function handleStreamingResponse(res, subprocess, cliInput, requestId, sub
             subprocess.on("content_delta", (event) => {
                 const text = event.event.delta?.text || "";
                 toolBuffer += text;
+                addOutputBytes(requestId, Buffer.byteLength(text, "utf8"));
             });
             subprocess.on("result", (_result) => {
                 isComplete = true;
+                updateRequest(requestId, { status: "completed" });
                 // Detect auth errors before forwarding
                 if (isAuthError(toolBuffer)) {
                     console.error("[Stream] Auth error detected in CLI output");
+                    updateRequest(requestId, { status: "error" });
                     if (!res.writableEnded) {
                         res.write(`data: ${JSON.stringify({
                             error: { message: "Claude CLI is not authenticated. Run: claude login", type: "auth_error", code: "not_authenticated" },
@@ -380,15 +387,19 @@ async function handleStreamingResponse(res, subprocess, cliInput, requestId, sub
                 const text = event.event.delta?.text || "";
                 if (!text)
                     return;
+                addOutputBytes(requestId, Buffer.byteLength(text, "utf8"));
                 ingestDelta(text);
             });
             subprocess.on("result", (_result) => {
                 isComplete = true;
+                updateRequest(requestId, { status: "completed" });
                 // Drain any held-back auth probe before finishing.
                 // drainAuthProbe() returns false if it terminated the stream
                 // with an auth error — in which case we have nothing more to do.
-                if (!drainAuthProbe())
+                if (!drainAuthProbe()) {
+                    updateRequest(requestId, { status: "error" });
                     return;
+                }
                 // Flush any buffered tail through bleed detection before finishing
                 flushTail();
                 if (!res.writableEnded) {
@@ -401,6 +412,7 @@ async function handleStreamingResponse(res, subprocess, cliInput, requestId, sub
             });
         }
         subprocess.on("error", (error) => {
+            updateRequest(requestId, { status: "error" });
             console.error("[Streaming] Error:", error.message);
             if (!res.writableEnded) {
                 res.write(`data: ${JSON.stringify({
@@ -411,6 +423,9 @@ async function handleStreamingResponse(res, subprocess, cliInput, requestId, sub
             resolve();
         });
         subprocess.on("close", (code) => {
+            if (code !== 0 && !isComplete) {
+                updateRequest(requestId, { status: "error" });
+            }
             // Subprocess exited - ensure response is closed
             if (!res.writableEnded) {
                 if (code !== 0 && !isComplete) {
@@ -457,6 +472,7 @@ async function handleNonStreamingResponse(res, subprocess, cliInput, requestId, 
             finalResult = result;
         });
         subprocess.on("error", (error) => {
+            updateRequest(requestId, { status: "error" });
             console.error("[NonStreaming] Error:", error.message);
             respond(() => {
                 res.status(500).json({
@@ -472,6 +488,7 @@ async function handleNonStreamingResponse(res, subprocess, cliInput, requestId, 
                     // Detect auth errors
                     if (isAuthError(resultText)) {
                         console.error("[NonStreaming] Auth error detected in CLI output");
+                        updateRequest(requestId, { status: "error" });
                         res.status(503).json({
                             error: { message: "Claude CLI is not authenticated. Run: claude login", type: "auth_error", code: "not_authenticated" },
                         });
@@ -482,9 +499,12 @@ async function handleNonStreamingResponse(res, subprocess, cliInput, requestId, 
                         ...finalResult,
                         result: stripAssistantBleed(resultText),
                     };
+                    const outputLength = Buffer.byteLength(finalResult.result ?? "", "utf8");
+                    updateRequest(requestId, { status: "completed", outputLength });
                     res.json(cliResultToOpenai(finalResult, requestId));
                 }
                 else {
+                    updateRequest(requestId, { status: "error" });
                     res.status(500).json({
                         error: {
                             message: `Claude CLI exited with code ${code} without response`,
@@ -528,6 +548,20 @@ export function handleHealth(_req, res) {
     res.json({
         status: "ok",
         provider: "claude-code-cli",
+        timestamp: new Date().toISOString(),
+    });
+}
+/**
+ * Handle GET /v1/requests — Returns recent request status for the monitor
+ */
+export function handleRequests(req, res) {
+    const rawN = req.query.n;
+    const n = typeof rawN === "string" ? parseInt(rawN, 10) : 20;
+    const limit = n === -1 ? undefined : (Number.isFinite(n) && n > 0 ? n : 20);
+    res.json({
+        requests: getRequests(limit),
+        active: getActiveCount(),
+        maxConcurrent: MAX_CONCURRENT,
         timestamp: new Date().toISOString(),
     });
 }

--- a/dist/server/routes.js
+++ b/dist/server/routes.js
@@ -42,7 +42,7 @@ export async function handleChatCompletions(req, res) {
             body.tools.length > 0 &&
             body.tool_choice !== "none";
         if (stream) {
-            await handleStreamingResponse(req, res, subprocess, cliInput, requestId, subOpts, hasTools);
+            await handleStreamingResponse(res, subprocess, cliInput, requestId, subOpts, hasTools);
         }
         else {
             await handleNonStreamingResponse(res, subprocess, cliInput, requestId, subOpts);
@@ -65,7 +65,7 @@ export async function handleChatCompletions(req, res) {
  *
  * Each content_delta event is immediately written to the response stream.
  */
-async function handleStreamingResponse(req, res, subprocess, cliInput, requestId, subOpts, hasTools = false) {
+async function handleStreamingResponse(res, subprocess, cliInput, requestId, subOpts, hasTools = false) {
     // Set SSE headers
     res.setHeader("Content-Type", "text/event-stream");
     res.setHeader("Cache-Control", "no-cache");
@@ -92,8 +92,6 @@ async function handleStreamingResponse(req, res, subprocess, cliInput, requestId
     return new Promise((resolve, reject) => {
         let lastModel = "claude-sonnet-4";
         let isComplete = false;
-        let isFirst = false; // role:"assistant" already sent in the announce chunk above
-        let allContent = ""; // Track all content for auth error detection
         // ── Bleed detection state ──────────────────────────────────
         // We hold back a small tail buffer (MAX_SENTINEL_LEN bytes) so a
         // bleed sentinel that straddles two delta chunks is still caught,
@@ -111,7 +109,9 @@ async function handleStreamingResponse(req, res, subprocess, cliInput, requestId
         let authProbe = "";
         let authProbeCleared = false;
         /**
-         * Write a delta chunk to the SSE stream.
+         * Write a content delta chunk to the SSE stream.
+         * The role:"assistant" announcement was already sent up-front, so
+         * subsequent deltas only carry the content payload.
          */
         function writeDelta(text) {
             if (!text || res.writableEnded)
@@ -123,15 +123,11 @@ async function handleStreamingResponse(req, res, subprocess, cliInput, requestId
                 model: lastModel,
                 choices: [{
                         index: 0,
-                        delta: {
-                            role: isFirst ? "assistant" : undefined,
-                            content: text,
-                        },
+                        delta: { content: text },
                         finish_reason: null,
                     }],
             };
             res.write(`data: ${JSON.stringify(chunk)}\n\n`);
-            isFirst = false;
         }
         /**
          * Process an incoming delta with bleed detection.
@@ -279,7 +275,6 @@ async function handleStreamingResponse(req, res, subprocess, cliInput, requestId
             subprocess.on("content_delta", (event) => {
                 const text = event.event.delta?.text || "";
                 toolBuffer += text;
-                allContent += text;
             });
             subprocess.on("result", (_result) => {
                 isComplete = true;
@@ -329,7 +324,6 @@ async function handleStreamingResponse(req, res, subprocess, cliInput, requestId
                 const text = event.event.delta?.text || "";
                 if (!text)
                     return;
-                allContent += text;
                 ingestDelta(text);
             });
             subprocess.on("result", (_result) => {

--- a/dist/server/routes.js
+++ b/dist/server/routes.js
@@ -311,9 +311,9 @@ async function handleStreamingResponse(res, subprocess, cliInput, requestId, sub
         subprocess.on("message", (msg) => {
             if (msg.type !== "stream_event")
                 return;
-            const eventType = msg.event?.type;
-            if (eventType === "content_block_start") {
-                const block = msg.event.content_block;
+            const event = msg.event;
+            if (event.type === "content_block_start") {
+                const block = event.content_block;
                 if (block?.type === "tool_use" && block.name) {
                     console.error(`[Stream] Tool call: ${block.name}`);
                 }

--- a/dist/server/routes.js
+++ b/dist/server/routes.js
@@ -102,6 +102,14 @@ async function handleStreamingResponse(req, res, subprocess, cliInput, requestId
         let bleedDetected = false;
         const BLEED_SENTINELS = ["\n[User]", "\n[Human]", "\nHuman:"];
         const MAX_SENTINEL_LEN = Math.max(...BLEED_SENTINELS.map((s) => s.length));
+        // ── Auth-error probe state ─────────────────────────────────
+        // Hold back the first AUTH_PROBE_BYTES of streamed text so we can
+        // detect "not logged in" before any of it is forwarded to the client.
+        // Once the buffer is large enough — or the stream ends — we either
+        // emit an auth error or flush the buffer through the normal pipeline.
+        const AUTH_PROBE_BYTES = 1024;
+        let authProbe = "";
+        let authProbeCleared = false;
         /**
          * Write a delta chunk to the SSE stream.
          */
@@ -176,6 +184,69 @@ async function handleStreamingResponse(req, res, subprocess, cliInput, requestId
             if (safe)
                 writeDelta(safe);
             tail = "";
+        }
+        /**
+         * Emit a structured auth error and tear down the stream.
+         * Used by both the early probe (in delta handler) and the late
+         * fallback (in result handler) so the wire format stays identical.
+         */
+        function emitAuthError() {
+            console.error("[Stream] Auth error detected — aborting stream");
+            if (!res.writableEnded) {
+                res.write(`data: ${JSON.stringify({
+                    error: { message: "Claude CLI is not authenticated. Run: claude login", type: "auth_error", code: "not_authenticated" },
+                })}\n\n`);
+                res.write("data: [DONE]\n\n");
+                res.end();
+            }
+            isComplete = true;
+            subprocess.kill();
+            resolve();
+        }
+        /**
+         * Buffer the first AUTH_PROBE_BYTES of streamed text and only forward
+         * it once we are confident it is not an auth error. This prevents
+         * "not logged in" content from leaking to the client before we can
+         * replace it with a structured auth_error.
+         *
+         * Returns true if the stream should keep running, false if we have
+         * already terminated it (auth error confirmed).
+         */
+        function ingestDelta(text) {
+            if (authProbeCleared) {
+                processDelta(text);
+                return true;
+            }
+            authProbe += text;
+            if (isAuthError(authProbe)) {
+                emitAuthError();
+                return false;
+            }
+            if (authProbe.length >= AUTH_PROBE_BYTES) {
+                authProbeCleared = true;
+                const drained = authProbe;
+                authProbe = "";
+                processDelta(drained);
+            }
+            return true;
+        }
+        /**
+         * Drain the auth probe buffer at end-of-stream. Returns false if an
+         * auth error was detected (caller should bail out without writing
+         * the normal completion chunks).
+         */
+        function drainAuthProbe() {
+            if (authProbeCleared || !authProbe)
+                return true;
+            if (isAuthError(authProbe)) {
+                emitAuthError();
+                return false;
+            }
+            authProbeCleared = true;
+            const drained = authProbe;
+            authProbe = "";
+            processDelta(drained);
+            return true;
         }
         // ──────────────────────────────────────────────────────────
         // Handle client disconnect
@@ -253,29 +324,21 @@ async function handleStreamingResponse(req, res, subprocess, cliInput, requestId
             });
         }
         else {
-            // ── Normal mode: stream deltas through bleed detection ────────────
+            // ── Normal mode: stream deltas through auth-probe + bleed pipeline ─
             subprocess.on("content_delta", (event) => {
                 const text = event.event.delta?.text || "";
                 if (!text)
                     return;
                 allContent += text;
-                processDelta(text);
+                ingestDelta(text);
             });
             subprocess.on("result", (_result) => {
                 isComplete = true;
-                // Detect auth errors before forwarding
-                if (isAuthError(allContent)) {
-                    console.error("[Stream] Auth error detected in CLI output");
-                    if (!res.writableEnded) {
-                        res.write(`data: ${JSON.stringify({
-                            error: { message: "Claude CLI is not authenticated. Run: claude login", type: "auth_error", code: "not_authenticated" },
-                        })}\n\n`);
-                        res.write("data: [DONE]\n\n");
-                        res.end();
-                    }
-                    resolve();
+                // Drain any held-back auth probe before finishing.
+                // drainAuthProbe() returns false if it terminated the stream
+                // with an auth error — in which case we have nothing more to do.
+                if (!drainAuthProbe())
                     return;
-                }
                 // Flush any buffered tail through bleed detection before finishing
                 flushTail();
                 if (!res.writableEnded) {

--- a/dist/server/routes.js
+++ b/dist/server/routes.js
@@ -1,188 +1,7 @@
 import { v4 as uuidv4 } from "uuid";
-import { spawn as nodeSpawn } from "child_process";
-import path from "path";
-import fs from "fs";
 import { ClaudeSubprocess } from "../subprocess/manager.js";
-import { openaiToCli, extractModel, stripAssistantBleed } from "../adapter/openai-to-cli.js";
+import { openaiToCli, stripAssistantBleed } from "../adapter/openai-to-cli.js";
 import { cliResultToOpenai, createDoneChunk, parseToolCalls, createToolCallChunks } from "../adapter/cli-to-openai.js";
-import { sessionManager } from "../session/manager.js";
-// ── Telegram Progress Reporter ─────────────────────────────────────
-// Shows real-time progress updates in Telegram while the CLI runs
-// tool calls (Bash, WebSearch, Read, etc.). Sends one message on the
-// first tool call, then edits it on subsequent calls, and deletes it
-// when the final response is ready.
-const TOOL_LABELS = {
-    "Bash": "執行命令",
-    "Read": "讀取檔案",
-    "Write": "寫入檔案",
-    "Edit": "編輯檔案",
-    "Grep": "搜尋內容",
-    "Glob": "搜尋檔案",
-    "WebSearch": "搜尋網頁",
-    "WebFetch": "讀取網頁",
-    "TodoRead": "讀取待辦",
-    "TodoWrite": "更新待辦",
-};
-let _cachedBotToken = undefined;
-function getTelegramBotToken() {
-    if (_cachedBotToken !== undefined)
-        return _cachedBotToken;
-    try {
-        const configPath = path.join(process.env.HOME || "/tmp", ".openclaw", "openclaw.json");
-        const config = JSON.parse(fs.readFileSync(configPath, "utf-8"));
-        _cachedBotToken = config?.channels?.telegram?.botToken || null;
-    }
-    catch (err) {
-        console.error("[ProgressReporter] Failed to read bot token:", err.message);
-        _cachedBotToken = null;
-    }
-    return _cachedBotToken;
-}
-async function telegramApi(method, params) {
-    const token = getTelegramBotToken();
-    if (!token)
-        return null;
-    try {
-        const resp = await fetch(`https://api.telegram.org/bot${token}/${method}`, {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify(params),
-        });
-        const data = await resp.json();
-        if (!data.ok) {
-            console.error(`[TelegramAPI] ${method} failed:`, data.description);
-        }
-        return data;
-    }
-    catch (err) {
-        console.error(`[TelegramAPI] ${method} error:`, err.message);
-        return null;
-    }
-}
-/**
- * Manages a single Telegram progress message that gets updated as
- * the CLI calls different tools. One instance per request.
- */
-class ProgressReporter {
-    static MIN_UPDATE_INTERVAL = 3000; // 3s between edits
-    chatId;
-    messageId = null;
-    toolHistory = [];
-    lastUpdateAt = 0;
-    pendingLabel = null;
-    throttleTimer = null;
-    isDeleted = false;
-    constructor(chatId) {
-        this.chatId = chatId;
-    }
-    /**
-     * Build the progress message text from tool history.
-     */
-    _buildText() {
-        if (this.toolHistory.length === 0)
-            return "⏳ 處理中...";
-        const lines = this.toolHistory.map((label, i) => {
-            if (i === 0)
-                return `⏳ ${label}...`;
-            return `     ${label}...`;
-        });
-        return lines.join("\n");
-    }
-    /**
-     * Report a new tool call. Sends or edits the progress message.
-     */
-    async report(toolName) {
-        if (this.isDeleted || !this.chatId)
-            return;
-        const label = TOOL_LABELS[toolName] || toolName;
-        if (this.toolHistory.length > 0 && this.toolHistory[this.toolHistory.length - 1] === label)
-            return;
-        this.toolHistory.push(label);
-        if (this.toolHistory.length > 6)
-            this.toolHistory = this.toolHistory.slice(-6);
-        const now = Date.now();
-        const elapsed = now - this.lastUpdateAt;
-        if (elapsed >= ProgressReporter.MIN_UPDATE_INTERVAL) {
-            await this._flush();
-        }
-        else {
-            this.pendingLabel = label;
-            if (!this.throttleTimer) {
-                this.throttleTimer = setTimeout(async () => {
-                    this.throttleTimer = null;
-                    if (!this.isDeleted)
-                        await this._flush();
-                }, ProgressReporter.MIN_UPDATE_INTERVAL - elapsed);
-            }
-        }
-    }
-    /**
-     * Actually send or edit the Telegram message.
-     */
-    async _flush() {
-        if (this.isDeleted)
-            return;
-        this.lastUpdateAt = Date.now();
-        this.pendingLabel = null;
-        const text = this._buildText();
-        if (!this.messageId) {
-            const result = await telegramApi("sendMessage", {
-                chat_id: this.chatId,
-                text,
-                disable_notification: true,
-            });
-            if (result?.ok) {
-                this.messageId = result.result.message_id;
-                console.error(`[ProgressReporter] Sent progress message #${this.messageId}`);
-            }
-        }
-        else {
-            await telegramApi("editMessageText", {
-                chat_id: this.chatId,
-                message_id: this.messageId,
-                text,
-            });
-        }
-    }
-    /**
-     * Clean up: delete the progress message when the final response arrives.
-     */
-    async cleanup() {
-        this.isDeleted = true;
-        if (this.throttleTimer) {
-            clearTimeout(this.throttleTimer);
-            this.throttleTimer = null;
-        }
-        if (this.messageId && this.chatId) {
-            await telegramApi("deleteMessage", {
-                chat_id: this.chatId,
-                message_id: this.messageId,
-            });
-            console.error(`[ProgressReporter] Deleted progress message #${this.messageId}`);
-        }
-    }
-}
-/**
- * Send a notification message to Telegram via oc-tool.
- * Fire-and-forget — errors are logged but don't affect the caller.
- */
-function notifyTelegram(message) {
-    const telegramId = process.env.TELEGRAM_NOTIFY_ID;
-    if (!telegramId)
-        return;
-    const ocTool = path.join(process.env.HOME || "/tmp", ".openclaw", "bin", "oc-tool");
-    try {
-        const proc = nodeSpawn(ocTool, ["message", "send", JSON.stringify({
-                channel: "telegram",
-                target: `telegram:${telegramId}`,
-                message,
-            })], { env: { ...process.env }, stdio: "ignore", detached: true });
-        proc.unref();
-    }
-    catch (err) {
-        console.error("[notifyTelegram] Failed:", err.message);
-    }
-}
 // ── Auth Error Detection ────────────────────────────────────────────
 const AUTH_ERROR_PATTERNS = ["not logged in", "please run /login"];
 function isAuthError(text) {
@@ -211,44 +30,13 @@ export async function handleChatCompletions(req, res) {
             });
             return;
         }
-        // Session management: determine if we should resume an existing session
-        const conversationId = body.user;
-        let hasExistingSession = false;
-        let claudeSessionId;
-        if (conversationId) {
-            const existing = sessionManager.get(conversationId);
-            if (existing) {
-                hasExistingSession = true;
-                claudeSessionId = existing.claudeSessionId;
-                existing.lastUsedAt = Date.now();
-                sessionManager.save().catch((err) => console.error("[SessionManager] Save error:", err));
-                console.error(`[Session] Resuming: ${conversationId} -> ${claudeSessionId}`);
-            }
-            else {
-                claudeSessionId = sessionManager.getOrCreate(conversationId, extractModel(body.model));
-                console.error(`[Session] New: ${conversationId} -> ${claudeSessionId}`);
-            }
-        }
-        // Convert to CLI input format (only latest message if resuming)
-        const cliInput = openaiToCli(body, hasExistingSession);
-        // Build subprocess options with session info
+        // Convert to CLI input format
+        const cliInput = openaiToCli(body);
         const subOpts = {
             model: cliInput.model,
             systemPrompt: cliInput.systemPrompt,
         };
-        if (hasExistingSession && claudeSessionId) {
-            subOpts.resumeSessionId = claudeSessionId;
-        }
-        else if (claudeSessionId) {
-            subOpts.sessionId = claudeSessionId;
-        }
         const subprocess = new ClaudeSubprocess();
-        // Handle resume failures: invalidate session so next request starts fresh
-        subprocess.on("resume_failed", () => {
-            console.error(`[Session] Resume failed, invalidating: ${conversationId}`);
-            if (conversationId)
-                sessionManager.delete(conversationId);
-        });
         // External tool calling: present and not explicitly disabled
         const hasTools = Array.isArray(body.tools) &&
             body.tools.length > 0 &&
@@ -310,6 +98,7 @@ async function handleStreamingResponse(req, res, subprocess, cliInput, requestId
         // We accumulate streamed text to detect [User]/[Human] bleed patterns.
         // Once a bleed sentinel is detected, we stop forwarding further deltas.
         let accumulated = "";
+        let totalFlushed = 0;
         let bleedDetected = false;
         // Longest sentinel we watch for, so we know how much tail to hold back
         const BLEED_SENTINELS = ["\n[User]", "\n[Human]", "\nHuman:"];
@@ -350,11 +139,9 @@ async function handleStreamingResponse(req, res, subprocess, cliInput, requestId
             // Check if the accumulated text contains a bleed sentinel
             const safe = stripAssistantBleed(accumulated);
             if (safe.length < accumulated.length) {
-                // Bleed found — write the safe portion and stop
+                // Bleed found — write only the unflushed safe portion and stop
                 bleedDetected = true;
-                // Only write the part we haven't written yet
-                const alreadyWritten = accumulated.length - incoming.length;
-                const safeNew = safe.slice(alreadyWritten);
+                const safeNew = safe.slice(totalFlushed);
                 if (safeNew)
                     writeDelta(safeNew);
                 console.error("[Stream] Bleed detected — halting delta stream");
@@ -363,10 +150,10 @@ async function handleStreamingResponse(req, res, subprocess, cliInput, requestId
             // No bleed yet, but hold back the last MAX_SENTINEL_LEN chars as a
             // look-ahead buffer in case a sentinel straddles two delta chunks.
             const safeLen = Math.max(0, accumulated.length - MAX_SENTINEL_LEN);
-            const alreadyFlushed = accumulated.length - incoming.length;
-            const toFlush = safeLen - alreadyFlushed;
+            const toFlush = safeLen - totalFlushed;
             if (toFlush > 0) {
-                writeDelta(accumulated.slice(alreadyFlushed, alreadyFlushed + toFlush));
+                writeDelta(accumulated.slice(totalFlushed, totalFlushed + toFlush));
+                totalFlushed += toFlush;
             }
         }
         /**
@@ -376,26 +163,19 @@ async function handleStreamingResponse(req, res, subprocess, cliInput, requestId
         function flushTail() {
             if (bleedDetected || res.writableEnded)
                 return;
-            const alreadyFlushed = Math.max(0, accumulated.length - MAX_SENTINEL_LEN);
-            const tail = accumulated.slice(alreadyFlushed);
-            if (!tail)
-                return;
-            const safe = stripAssistantBleed(accumulated).slice(alreadyFlushed);
-            if (safe)
-                writeDelta(safe);
+            const safe = stripAssistantBleed(accumulated);
+            const remaining = safe.slice(totalFlushed);
+            if (remaining)
+                writeDelta(remaining);
         }
         // ──────────────────────────────────────────────────────────
-        // Progress reporter for Telegram
-        const telegramChatId = process.env.TELEGRAM_NOTIFY_ID || null;
-        const progress = new ProgressReporter(telegramChatId);
         // Handle client disconnect
         res.on("close", () => {
             if (!isComplete)
                 subprocess.kill();
-            progress.cleanup().catch(() => { });
             resolve();
         });
-        // Detect tool calls for progress reporting
+        // Log tool calls
         subprocess.on("message", (msg) => {
             if (msg.type !== "stream_event")
                 return;
@@ -404,7 +184,6 @@ async function handleStreamingResponse(req, res, subprocess, cliInput, requestId
                 const block = msg.event.content_block;
                 if (block?.type === "tool_use" && block.name) {
                     console.error(`[Stream] Tool call: ${block.name}`);
-                    progress.report(block.name).catch(() => { });
                 }
             }
         });
@@ -424,7 +203,6 @@ async function handleStreamingResponse(req, res, subprocess, cliInput, requestId
             });
             subprocess.on("result", (_result) => {
                 isComplete = true;
-                progress.cleanup().catch(() => { });
                 // Detect auth errors before forwarding
                 if (isAuthError(toolBuffer)) {
                     console.error("[Stream] Auth error detected in CLI output");
@@ -480,7 +258,6 @@ async function handleStreamingResponse(req, res, subprocess, cliInput, requestId
                 // Detect auth errors before forwarding
                 if (isAuthError(allContent)) {
                     console.error("[Stream] Auth error detected in CLI output");
-                    progress.cleanup().catch(() => { });
                     if (!res.writableEnded) {
                         res.write(`data: ${JSON.stringify({
                             error: { message: "Claude CLI is not authenticated. Run: claude login", type: "auth_error", code: "not_authenticated" },
@@ -493,8 +270,6 @@ async function handleStreamingResponse(req, res, subprocess, cliInput, requestId
                 }
                 // Flush any buffered tail through bleed detection before finishing
                 flushTail();
-                // Clean up progress message before sending final response
-                progress.cleanup().catch(() => { });
                 if (!res.writableEnded) {
                     const doneChunk = createDoneChunk(requestId, lastModel);
                     res.write(`data: ${JSON.stringify(doneChunk)}\n\n`);
@@ -506,12 +281,6 @@ async function handleStreamingResponse(req, res, subprocess, cliInput, requestId
         }
         subprocess.on("error", (error) => {
             console.error("[Streaming] Error:", error.message);
-            // Clean up progress message
-            progress.cleanup().catch(() => { });
-            // Notify via Telegram if it's a timeout
-            if (error.message.includes("timed out")) {
-                notifyTelegram(`⚠️ 任務超時被終止：${error.message}`);
-            }
             if (!res.writableEnded) {
                 res.write(`data: ${JSON.stringify({
                     error: { message: error.message, type: "server_error", code: null },
@@ -556,9 +325,6 @@ async function handleNonStreamingResponse(res, subprocess, cliInput, requestId, 
         });
         subprocess.on("error", (error) => {
             console.error("[NonStreaming] Error:", error.message);
-            if (error.message.includes("timed out")) {
-                notifyTelegram(`⚠️ 任務超時被終止：${error.message}`);
-            }
             res.status(500).json({
                 error: { message: error.message, type: "server_error", code: null },
             });

--- a/dist/server/service.d.ts
+++ b/dist/server/service.d.ts
@@ -1,0 +1,32 @@
+export type ServicePlatform = "darwin" | "linux-systemd" | null;
+export declare const SERVICE_LABEL = "com.claude-max-api";
+export declare const SERVICE_UNIT = "claude-max-api";
+/**
+ * Detect which service backend (if any) we can drive on the current host.
+ * Returns null on unsupported platforms so callers can fall back to the
+ * built-in daemonize() path.
+ */
+export declare function detectPlatform(): ServicePlatform;
+export interface ServiceStatus {
+    installed: boolean;
+    running: boolean;
+    /** Free-form human-readable detail line. */
+    detail: string;
+}
+export declare function isInstalled(): boolean;
+export declare function serviceStatus(): ServiceStatus;
+/**
+ * Write the service unit and register it with the platform's init system.
+ * Idempotent: if already installed, the unit is overwritten and the service
+ * restarted so upgrades pick up the new `node`/script paths.
+ */
+export declare function installService(port: number): void;
+export declare function uninstallService(): void;
+/**
+ * Start the already-installed service. Caller should check isInstalled()
+ * first; this function throws if invoked when the service isn't registered.
+ */
+export declare function startService(): void;
+export declare function stopService(): void;
+export declare function restartService(): void;
+//# sourceMappingURL=service.d.ts.map

--- a/dist/server/service.js
+++ b/dist/server/service.js
@@ -1,0 +1,320 @@
+/**
+ * Platform-aware OS service manager.
+ *
+ * Registers the proxy as a user-level service that auto-starts on login and
+ * exposes a cross-platform start/stop/restart/status API. The `standalone`
+ * CLI dispatches to this module so `claude-max-api start` behaves the same
+ * way whether we're on macOS (launchd) or Linux with systemd user units.
+ *
+ *   macOS          ~/Library/LaunchAgents/com.claude-max-api.plist  (launchctl)
+ *   Linux/systemd  ~/.config/systemd/user/claude-max-api.service    (systemctl --user)
+ *   anything else  null platform — callers fall back to the built-in daemonize()
+ *
+ * We intentionally stay in the user domain: no root, no LaunchDaemons, no
+ * system-level systemd units. That matches the security posture of the
+ * foreground binary (the proxy itself should never run as root).
+ */
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { LOG_FILE } from "./daemon.js";
+export const SERVICE_LABEL = "com.claude-max-api";
+export const SERVICE_UNIT = "claude-max-api";
+// ── Platform detection ────────────────────────────────────────────
+/**
+ * Detect which service backend (if any) we can drive on the current host.
+ * Returns null on unsupported platforms so callers can fall back to the
+ * built-in daemonize() path.
+ */
+export function detectPlatform() {
+    if (process.platform === "darwin")
+        return "darwin";
+    if (process.platform === "linux") {
+        const r = spawnSync("systemctl", ["--user", "--version"], {
+            stdio: ["ignore", "ignore", "ignore"],
+        });
+        if (r.status === 0)
+            return "linux-systemd";
+    }
+    return null;
+}
+// ── Paths ─────────────────────────────────────────────────────────
+function plistPath() {
+    return path.join(os.homedir(), "Library", "LaunchAgents", `${SERVICE_LABEL}.plist`);
+}
+function unitPath() {
+    return path.join(os.homedir(), ".config", "systemd", "user", `${SERVICE_UNIT}.service`);
+}
+/**
+ * Absolute path to the standalone.js that should be invoked by the service.
+ * Resolves relative to *this* compiled module (dist/server/service.js), so
+ * whichever directory npm/global-install unpacks us into is the one that
+ * gets baked into the service definition.
+ */
+function resolveScriptPath() {
+    const here = fileURLToPath(import.meta.url);
+    return path.join(path.dirname(here), "standalone.js");
+}
+function plistBody(opts) {
+    // KeepAlive.SuccessfulExit=false means launchd only restarts us on
+    // abnormal exits (crash, OOM). A clean shutdown via `claude-max-api stop`
+    // leaves the job unloaded, which is what the user wants.
+    return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key><string>${SERVICE_LABEL}</string>
+    <key>RunAtLoad</key><true/>
+    <key>KeepAlive</key>
+    <dict>
+        <key>SuccessfulExit</key><false/>
+    </dict>
+    <key>ProgramArguments</key>
+    <array>
+        <string>${opts.nodePath}</string>
+        <string>${opts.scriptPath}</string>
+        <string>--foreground</string>
+        <string>${opts.port}</string>
+    </array>
+    <key>StandardOutPath</key><string>${LOG_FILE}</string>
+    <key>StandardErrorPath</key><string>${LOG_FILE}</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key><string>${opts.home}</string>
+        <key>PATH</key><string>${opts.path}</string>
+    </dict>
+</dict>
+</plist>
+`;
+}
+function unitBody(opts) {
+    // Restart=on-failure mirrors launchd's "restart on crash" posture:
+    // a clean `systemctl --user stop` leaves the service stopped.
+    return `[Unit]
+Description=Claude Max API Proxy
+After=network.target
+
+[Service]
+Type=simple
+Environment=HOME=${opts.home}
+Environment=PATH=${opts.path}
+ExecStart=${opts.nodePath} ${opts.scriptPath} --foreground ${opts.port}
+Restart=on-failure
+RestartSec=5s
+StandardOutput=append:${LOG_FILE}
+StandardError=append:${LOG_FILE}
+
+[Install]
+WantedBy=default.target
+`;
+}
+// ── Option resolution ─────────────────────────────────────────────
+function buildOptions(port) {
+    const home = os.homedir();
+    // Seed PATH with common bin dirs so the service can find `claude`,
+    // `oc-tool`, `ffmpeg`, etc. even when launched outside a login shell.
+    const seeded = [
+        path.join(home, ".npm-global", "bin"),
+        path.join(home, ".nvm", "versions", "node"),
+        path.join(home, ".local", "bin"),
+        "/opt/homebrew/bin",
+        "/usr/local/bin",
+        "/usr/bin",
+        "/bin",
+    ];
+    const inherited = (process.env.PATH ?? "").split(":").filter(Boolean);
+    const merged = Array.from(new Set([...inherited, ...seeded])).join(":");
+    return {
+        port,
+        nodePath: process.execPath,
+        scriptPath: resolveScriptPath(),
+        home,
+        path: merged,
+    };
+}
+// ── Helpers ───────────────────────────────────────────────────────
+function run(cmd, args) {
+    const r = spawnSync(cmd, args, { stdio: ["ignore", "pipe", "pipe"], encoding: "utf8" });
+    return {
+        ok: r.status === 0,
+        stdout: (r.stdout ?? "").toString(),
+        stderr: (r.stderr ?? "").toString(),
+        status: r.status,
+    };
+}
+function uid() {
+    return process.getuid?.() ?? 0;
+}
+function ensureDir(p) {
+    fs.mkdirSync(path.dirname(p), { recursive: true });
+}
+export function isInstalled() {
+    const platform = detectPlatform();
+    if (platform === "darwin")
+        return fs.existsSync(plistPath());
+    if (platform === "linux-systemd")
+        return fs.existsSync(unitPath());
+    return false;
+}
+export function serviceStatus() {
+    const platform = detectPlatform();
+    if (!platform)
+        return { installed: false, running: false, detail: "platform unsupported" };
+    if (platform === "darwin") {
+        if (!fs.existsSync(plistPath())) {
+            return { installed: false, running: false, detail: "not installed" };
+        }
+        const r = run("launchctl", ["print", `gui/${uid()}/${SERVICE_LABEL}`]);
+        if (!r.ok)
+            return { installed: true, running: false, detail: "loaded=no" };
+        // `state = running` appears in the print output when the process is alive.
+        const running = /state\s*=\s*running/.test(r.stdout);
+        return {
+            installed: true,
+            running,
+            detail: running ? "state=running" : "state=not running",
+        };
+    }
+    // linux-systemd
+    if (!fs.existsSync(unitPath())) {
+        return { installed: false, running: false, detail: "not installed" };
+    }
+    const r = run("systemctl", ["--user", "is-active", SERVICE_UNIT]);
+    const state = r.stdout.trim() || r.stderr.trim() || "unknown";
+    return { installed: true, running: state === "active", detail: `state=${state}` };
+}
+/**
+ * Write the service unit and register it with the platform's init system.
+ * Idempotent: if already installed, the unit is overwritten and the service
+ * restarted so upgrades pick up the new `node`/script paths.
+ */
+export function installService(port) {
+    const platform = detectPlatform();
+    if (!platform) {
+        throw new Error(`Unsupported platform: ${process.platform}. Use 'claude-max-api' directly or the built-in 'start' fallback.`);
+    }
+    if (uid() === 0) {
+        throw new Error("Refusing to install service as root — run without sudo so the unit lives under your own user.");
+    }
+    const opts = buildOptions(port);
+    fs.mkdirSync(path.dirname(LOG_FILE), { recursive: true });
+    if (platform === "darwin") {
+        const target = plistPath();
+        ensureDir(target);
+        // If the unit is already loaded, bootout first so the new plist takes
+        // effect on next bootstrap. Ignore failures — service may be absent.
+        run("launchctl", ["bootout", `gui/${uid()}/${SERVICE_LABEL}`]);
+        fs.writeFileSync(target, plistBody(opts));
+        const r = run("launchctl", ["bootstrap", `gui/${uid()}`, target]);
+        if (!r.ok) {
+            throw new Error(`launchctl bootstrap failed (status ${r.status}): ${r.stderr.trim() || r.stdout.trim()}`);
+        }
+        return;
+    }
+    // linux-systemd
+    const target = unitPath();
+    ensureDir(target);
+    fs.writeFileSync(target, unitBody(opts));
+    let r = run("systemctl", ["--user", "daemon-reload"]);
+    if (!r.ok)
+        throw new Error(`systemctl --user daemon-reload failed: ${r.stderr.trim()}`);
+    r = run("systemctl", ["--user", "enable", "--now", SERVICE_UNIT]);
+    if (!r.ok) {
+        throw new Error(`systemctl --user enable --now failed (status ${r.status}): ${r.stderr.trim() || r.stdout.trim()}`);
+    }
+}
+export function uninstallService() {
+    const platform = detectPlatform();
+    if (!platform)
+        return;
+    if (platform === "darwin") {
+        run("launchctl", ["bootout", `gui/${uid()}/${SERVICE_LABEL}`]);
+        try {
+            fs.unlinkSync(plistPath());
+        }
+        catch {
+            /* already gone */
+        }
+        return;
+    }
+    run("systemctl", ["--user", "disable", "--now", SERVICE_UNIT]);
+    try {
+        fs.unlinkSync(unitPath());
+    }
+    catch {
+        /* already gone */
+    }
+    run("systemctl", ["--user", "daemon-reload"]);
+}
+/**
+ * Start the already-installed service. Caller should check isInstalled()
+ * first; this function throws if invoked when the service isn't registered.
+ */
+export function startService() {
+    const platform = detectPlatform();
+    if (!platform)
+        throw new Error("Service backend not available on this platform.");
+    if (platform === "darwin") {
+        if (!fs.existsSync(plistPath())) {
+            throw new Error("Service is not installed. Run: claude-max-api install-service");
+        }
+        // bootstrap brings the service up and (because RunAtLoad=true) starts
+        // it. If it's already loaded, bootstrap exits non-zero — fall back to
+        // kickstart in that case.
+        let r = run("launchctl", ["bootstrap", `gui/${uid()}`, plistPath()]);
+        if (!r.ok) {
+            r = run("launchctl", ["kickstart", `gui/${uid()}/${SERVICE_LABEL}`]);
+            if (!r.ok) {
+                throw new Error(`launchctl start failed: ${r.stderr.trim() || r.stdout.trim()}`);
+            }
+        }
+        return;
+    }
+    if (!fs.existsSync(unitPath())) {
+        throw new Error("Service is not installed. Run: claude-max-api install-service");
+    }
+    const r = run("systemctl", ["--user", "start", SERVICE_UNIT]);
+    if (!r.ok)
+        throw new Error(`systemctl --user start failed: ${r.stderr.trim()}`);
+}
+export function stopService() {
+    const platform = detectPlatform();
+    if (!platform)
+        throw new Error("Service backend not available on this platform.");
+    if (platform === "darwin") {
+        // bootout unloads the job and SIGTERMs the process. On a fresh install
+        // where the job was never loaded, this exits non-zero — treat that as
+        // a no-op.
+        run("launchctl", ["bootout", `gui/${uid()}/${SERVICE_LABEL}`]);
+        return;
+    }
+    const r = run("systemctl", ["--user", "stop", SERVICE_UNIT]);
+    if (!r.ok)
+        throw new Error(`systemctl --user stop failed: ${r.stderr.trim()}`);
+}
+export function restartService() {
+    const platform = detectPlatform();
+    if (!platform)
+        throw new Error("Service backend not available on this platform.");
+    if (platform === "darwin") {
+        if (!fs.existsSync(plistPath())) {
+            throw new Error("Service is not installed. Run: claude-max-api install-service");
+        }
+        // -k SIGTERMs the current instance and KeepAlive brings it back up.
+        // If the service wasn't running, kickstart alone starts it.
+        let r = run("launchctl", ["kickstart", "-k", `gui/${uid()}/${SERVICE_LABEL}`]);
+        if (!r.ok) {
+            // May not be loaded yet — bootstrap brings it up fresh.
+            r = run("launchctl", ["bootstrap", `gui/${uid()}`, plistPath()]);
+            if (!r.ok)
+                throw new Error(`launchctl restart failed: ${r.stderr.trim()}`);
+        }
+        return;
+    }
+    const r = run("systemctl", ["--user", "restart", SERVICE_UNIT]);
+    if (!r.ok)
+        throw new Error(`systemctl --user restart failed: ${r.stderr.trim()}`);
+}
+//# sourceMappingURL=service.js.map

--- a/dist/server/standalone.js
+++ b/dist/server/standalone.js
@@ -19,6 +19,7 @@
  * pidfile once the listener is up.
  */
 import fs from "node:fs";
+import http from "node:http";
 import { spawn } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { startServer, stopServer } from "./index.js";
@@ -31,6 +32,7 @@ const SUBCOMMANDS = new Set([
     "restart",
     "status",
     "logs",
+    "mon",
     "help",
     "--help",
     "-h",
@@ -54,6 +56,7 @@ function printHelp() {
   claude-max-api restart [port]   Stop then start in the background
   claude-max-api status           Show whether the daemon is running
   claude-max-api logs [-f]        Print (or follow) the daemon log file
+  claude-max-api mon [-n NUM]     Monitor recent requests (default 20, -1 = all)
   claude-max-api help             Show this help
 
 State files:
@@ -192,6 +195,94 @@ function cmdLogs(follow) {
         process.stdout.write(fs.readFileSync(LOG_FILE));
     }
 }
+function httpGet(url) {
+    return new Promise((resolve, reject) => {
+        http.get(url, (res) => {
+            let data = "";
+            res.on("data", (chunk) => { data += chunk.toString(); });
+            res.on("end", () => resolve(data));
+        }).on("error", reject);
+    });
+}
+function formatBytes(bytes) {
+    if (bytes < 1024)
+        return `${bytes} B`;
+    const kb = bytes / 1024;
+    if (kb < 1024)
+        return `${kb.toFixed(1)} KB`;
+    const mb = kb / 1024;
+    return `${mb.toFixed(1)} MB`;
+}
+function formatElapsed(ms) {
+    if (ms < 1000)
+        return `${ms}ms`;
+    const s = ms / 1000;
+    if (s < 60)
+        return `${s.toFixed(1)}s`;
+    const m = Math.floor(s / 60);
+    const rem = s - m * 60;
+    return `${m}m${rem.toFixed(0)}s`;
+}
+function renderTable(data, port) {
+    const lines = [];
+    lines.push(`Claude Max API \u2014 Request Monitor (port ${port})`);
+    lines.push("\u2501".repeat(76));
+    lines.push(` ${"Request ID".padEnd(26)} ${"Input".padStart(9)} ${"Output".padStart(9)} ${"Status".padEnd(14)} ${"Elapsed".padStart(8)}`);
+    lines.push("\u2500".repeat(76));
+    if (data.requests.length === 0) {
+        lines.push("  (no requests yet)");
+    }
+    else {
+        for (const r of data.requests) {
+            const id = r.id.length > 24 ? r.id.slice(0, 22) + ".." : r.id.padEnd(24);
+            const input = formatBytes(r.inputLength).padStart(9);
+            const output = formatBytes(r.outputLength).padStart(9);
+            const status = r.status.padEnd(14);
+            const elapsed = formatElapsed(r.elapsedMs).padStart(8);
+            lines.push(` ${id}  ${input} ${output}  ${status} ${elapsed}`);
+        }
+    }
+    lines.push("\u2501".repeat(76));
+    const ts = data.timestamp.replace("T", " ").replace(/\.\d+Z$/, "");
+    lines.push(` Active: ${data.active} / ${data.maxConcurrent}    Total: ${data.requests.length}    Updated: ${ts}`);
+    return lines.join("\n");
+}
+async function cmdMon(port, n) {
+    const url = `http://127.0.0.1:${port}/v1/requests?n=${n}`;
+    // Verify connectivity once before entering the loop.
+    try {
+        await httpGet(`http://127.0.0.1:${port}/health`);
+    }
+    catch {
+        console.error(`Cannot reach server at http://127.0.0.1:${port}. Is it running?`);
+        process.exit(1);
+    }
+    let running = true;
+    const shutdown = () => {
+        running = false;
+        // Show cursor again and move below the table.
+        process.stdout.write("\x1b[?25h");
+        process.exit(0);
+    };
+    process.on("SIGINT", shutdown);
+    process.on("SIGTERM", shutdown);
+    // Hide cursor for cleaner refreshes.
+    process.stdout.write("\x1b[?25l");
+    while (running) {
+        try {
+            const raw = await httpGet(url);
+            const data = JSON.parse(raw);
+            // Clear screen and move cursor to top-left.
+            process.stdout.write("\x1b[2J\x1b[H");
+            process.stdout.write(renderTable(data, port) + "\n");
+        }
+        catch {
+            process.stdout.write("\x1b[2J\x1b[H");
+            process.stdout.write(`Connection lost to http://127.0.0.1:${port} \u2014 retrying...\n`);
+        }
+        await new Promise((r) => setTimeout(r, 1000));
+    }
+}
 async function main() {
     const arg0 = process.argv[2];
     // Internal: invoked by daemonize() in the background child.
@@ -217,6 +308,24 @@ async function main() {
             case "logs": {
                 const follow = process.argv[3] === "-f" || process.argv[3] === "--follow";
                 cmdLogs(follow);
+                return;
+            }
+            case "mon": {
+                // Parse -n NUMBER from remaining args
+                let monN = 20;
+                const monArgs = process.argv.slice(3);
+                for (let i = 0; i < monArgs.length; i++) {
+                    if (monArgs[i] === "-n" && i + 1 < monArgs.length) {
+                        monN = parseInt(monArgs[i + 1], 10);
+                        if (isNaN(monN))
+                            monN = 20;
+                        break;
+                    }
+                }
+                // Determine port from running daemon or fall back to default.
+                const daemon = getRunningDaemon();
+                const monPort = daemon?.port ?? DEFAULT_PORT;
+                await cmdMon(monPort, monN);
                 return;
             }
             case "help":

--- a/dist/server/standalone.js
+++ b/dist/server/standalone.js
@@ -1,25 +1,69 @@
 #!/usr/bin/env node
 /**
- * Standalone server for testing without OpenClaw
+ * Standalone server entry point for `claude-max-api`.
  *
  * Usage:
- *   npm run start
- *   # or
- *   node dist/server/standalone.js [port]
+ *   claude-max-api                  Run in the foreground (default port 3456)
+ *   claude-max-api 3457             Run in the foreground on port 3457
+ *   claude-max-api start [port]     Daemonize and return immediately
+ *   claude-max-api stop             Stop the running daemon
+ *   claude-max-api restart [port]   Stop then start in the background
+ *   claude-max-api status           Show whether the daemon is running
+ *   claude-max-api logs [-f]        Print (or follow) the daemon log file
+ *
+ * The `start` family of commands uses ~/.claude-max-api/proxy.pid as a
+ * pidfile and ~/.claude-max-api/proxy.log as the redirected log file.
+ *
+ * The hidden `--foreground` argument is what the parent passes to the
+ * background child after spawning it; it makes the child write its own
+ * pidfile once the listener is up.
  */
+import fs from "node:fs";
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
 import { startServer, stopServer } from "./index.js";
 import { verifyClaude, verifyAuth } from "../subprocess/manager.js";
+import { LOG_FILE, PID_FILE, daemonize, getRunningDaemon, removePidFile, stopDaemon, waitForPidFile, writePidFile, } from "./daemon.js";
 const DEFAULT_PORT = 3456;
-async function main() {
-    console.log("Claude Code CLI Provider - Standalone Server");
-    console.log("============================================\n");
-    // Parse port from command line
-    const port = parseInt(process.argv[2] || String(DEFAULT_PORT), 10);
+const SUBCOMMANDS = new Set([
+    "start",
+    "stop",
+    "restart",
+    "status",
+    "logs",
+    "help",
+    "--help",
+    "-h",
+]);
+function parsePort(arg) {
+    if (!arg)
+        return DEFAULT_PORT;
+    const port = parseInt(arg, 10);
     if (isNaN(port) || port < 1 || port > 65535) {
-        console.error(`Invalid port: ${process.argv[2]}`);
+        console.error(`Invalid port: ${arg}`);
         process.exit(1);
     }
-    // Verify Claude CLI
+    return port;
+}
+function printHelp() {
+    console.log(`Usage:
+  claude-max-api                  Run in the foreground (default port ${DEFAULT_PORT})
+  claude-max-api <port>           Run in the foreground on the given port
+  claude-max-api start [port]     Daemonize and return immediately
+  claude-max-api stop             Stop the running daemon
+  claude-max-api restart [port]   Stop then start in the background
+  claude-max-api status           Show whether the daemon is running
+  claude-max-api logs [-f]        Print (or follow) the daemon log file
+  claude-max-api help             Show this help
+
+State files:
+  pidfile: ${PID_FILE}
+  log:     ${LOG_FILE}
+`);
+}
+async function runForeground(port, registerPidFile) {
+    console.log("Claude Code CLI Provider - Standalone Server");
+    console.log("============================================\n");
     console.log("Checking Claude CLI...");
     const cliCheck = await verifyClaude();
     if (!cliCheck.ok) {
@@ -27,7 +71,6 @@ async function main() {
         process.exit(1);
     }
     console.log(`  Claude CLI: ${cliCheck.version || "OK"}`);
-    // Verify authentication
     console.log("Checking authentication...");
     const authCheck = await verifyAuth();
     if (!authCheck.ok) {
@@ -36,27 +79,156 @@ async function main() {
         process.exit(1);
     }
     console.log("  Authentication: OK\n");
-    // Start server
     try {
         await startServer({ port });
-        console.log("\nServer ready. Test with:");
-        console.log(`  curl -X POST http://localhost:${port}/v1/chat/completions \\`);
-        console.log(`    -H "Content-Type: application/json" \\`);
-        console.log(`    -d '{"model": "claude-sonnet-4", "messages": [{"role": "user", "content": "Hello!"}]}'`);
-        console.log("\nPress Ctrl+C to stop.\n");
     }
     catch (err) {
         console.error("Failed to start server:", err);
         process.exit(1);
     }
-    // Handle graceful shutdown
+    if (registerPidFile) {
+        writePidFile({
+            pid: process.pid,
+            port,
+            startedAt: new Date().toISOString(),
+        });
+        console.log(`[Daemon] Registered pidfile at ${PID_FILE}`);
+    }
+    console.log("\nServer ready. Test with:");
+    console.log(`  curl -X POST http://localhost:${port}/v1/chat/completions \\`);
+    console.log(`    -H "Content-Type: application/json" \\`);
+    console.log(`    -d '{"model": "claude-sonnet-4", "messages": [{"role": "user", "content": "Hello!"}]}'`);
+    if (registerPidFile) {
+        console.log("\nRunning in background. Send SIGTERM (or `claude-max-api stop`) to stop.\n");
+    }
+    else {
+        console.log("\nPress Ctrl+C to stop.\n");
+    }
     const shutdown = async () => {
         console.log("\nShutting down...");
+        if (registerPidFile)
+            removePidFile();
         await stopServer();
         process.exit(0);
     };
     process.on("SIGINT", shutdown);
     process.on("SIGTERM", shutdown);
+}
+async function cmdStart(port) {
+    const existing = getRunningDaemon();
+    if (existing) {
+        console.error(`Server is already running (pid ${existing.pid}, port ${existing.port}). Use 'stop' or 'restart' first.`);
+        process.exit(1);
+    }
+    const scriptPath = fileURLToPath(import.meta.url);
+    const childPid = daemonize(scriptPath, [String(port)]);
+    console.log(`Starting Claude Max API proxy in the background (initial pid ${childPid})...`);
+    try {
+        const info = await waitForPidFile();
+        console.log(`Server is running (pid ${info.pid}) on port ${info.port}.`);
+        console.log(`Logs: ${LOG_FILE}`);
+    }
+    catch (err) {
+        console.error(`Failed to confirm background startup: ${err.message}`);
+        process.exit(1);
+    }
+}
+async function cmdStop() {
+    const result = await stopDaemon();
+    if (result.pid === null) {
+        console.log("No running server (no pidfile or stale pidfile).");
+        return;
+    }
+    if (result.stopped) {
+        console.log(`Stopped server (pid ${result.pid}).`);
+    }
+    else {
+        console.error(`Failed to stop server (pid ${result.pid}).`);
+        process.exit(1);
+    }
+}
+function cmdStatus() {
+    const info = getRunningDaemon();
+    if (!info) {
+        console.log("Not running.");
+        // systemd-style "program not running" exit code, so shell scripts can
+        // distinguish "not running" from a real error like "permission denied".
+        process.exit(3);
+    }
+    console.log(`Running (pid ${info.pid}) on port ${info.port}, started ${info.startedAt}.`);
+    console.log(`Logs: ${LOG_FILE}`);
+}
+async function cmdRestart(port) {
+    const result = await stopDaemon();
+    if (result.stopped) {
+        console.log(`Stopped previous server (pid ${result.pid}).`);
+    }
+    await cmdStart(port);
+}
+function cmdLogs(follow) {
+    if (!fs.existsSync(LOG_FILE)) {
+        console.log(`No logs yet at ${LOG_FILE}.`);
+        return;
+    }
+    if (follow) {
+        // Use tail -f rather than reimplementing it. tail is on every Unix
+        // system the proxy is expected to run on (Linux + macOS).
+        const tail = spawn("tail", ["-n", "200", "-f", LOG_FILE], {
+            stdio: "inherit",
+        });
+        tail.on("exit", (code) => process.exit(code ?? 0));
+        const forward = (sig) => {
+            try {
+                tail.kill(sig);
+            }
+            catch {
+                /* ignore */
+            }
+        };
+        process.on("SIGINT", () => forward("SIGINT"));
+        process.on("SIGTERM", () => forward("SIGTERM"));
+    }
+    else {
+        process.stdout.write(fs.readFileSync(LOG_FILE));
+    }
+}
+async function main() {
+    const arg0 = process.argv[2];
+    // Internal: invoked by daemonize() in the background child.
+    if (arg0 === "--foreground") {
+        const port = parsePort(process.argv[3]);
+        await runForeground(port, true);
+        return;
+    }
+    if (arg0 && SUBCOMMANDS.has(arg0)) {
+        switch (arg0) {
+            case "start":
+                await cmdStart(parsePort(process.argv[3]));
+                return;
+            case "stop":
+                await cmdStop();
+                return;
+            case "restart":
+                await cmdRestart(parsePort(process.argv[3]));
+                return;
+            case "status":
+                cmdStatus();
+                return;
+            case "logs": {
+                const follow = process.argv[3] === "-f" || process.argv[3] === "--follow";
+                cmdLogs(follow);
+                return;
+            }
+            case "help":
+            case "--help":
+            case "-h":
+                printHelp();
+                return;
+        }
+    }
+    // Backwards compat: `claude-max-api [port]` runs in the foreground.
+    const port = parsePort(arg0);
+    await runForeground(port, false);
 }
 main().catch((err) => {
     console.error("Unexpected error:", err);

--- a/dist/server/standalone.js
+++ b/dist/server/standalone.js
@@ -25,6 +25,7 @@ import { fileURLToPath } from "node:url";
 import { startServer, stopServer } from "./index.js";
 import { verifyClaude, verifyAuth } from "../subprocess/manager.js";
 import { LOG_FILE, PID_FILE, daemonize, getRunningDaemon, removePidFile, stopDaemon, waitForPidFile, writePidFile, } from "./daemon.js";
+import { detectPlatform, installService, isInstalled, restartService, serviceStatus, startService, stopService, uninstallService, } from "./service.js";
 const DEFAULT_PORT = 3456;
 const SUBCOMMANDS = new Set([
     "start",
@@ -33,6 +34,8 @@ const SUBCOMMANDS = new Set([
     "status",
     "logs",
     "mon",
+    "install-service",
+    "uninstall-service",
     "help",
     "--help",
     "-h",
@@ -49,15 +52,17 @@ function parsePort(arg) {
 }
 function printHelp() {
     console.log(`Usage:
-  claude-max-api                  Run in the foreground (default port ${DEFAULT_PORT})
-  claude-max-api <port>           Run in the foreground on the given port
-  claude-max-api start [port]     Daemonize and return immediately
-  claude-max-api stop             Stop the running daemon
-  claude-max-api restart [port]   Stop then start in the background
-  claude-max-api status           Show whether the daemon is running
-  claude-max-api logs [-f]        Print (or follow) the daemon log file
-  claude-max-api mon [-n NUM]     Monitor recent requests (default 20, -1 = all)
-  claude-max-api help             Show this help
+  claude-max-api                         Run in the foreground (default port ${DEFAULT_PORT})
+  claude-max-api <port>                  Run in the foreground on the given port
+  claude-max-api install-service [port]  Register as a login service (launchd/systemd) and start it
+  claude-max-api uninstall-service       Stop the service and remove its unit file
+  claude-max-api start [port]            Start the service (falls back to built-in daemon if no service backend)
+  claude-max-api stop                    Stop the service (or built-in daemon)
+  claude-max-api restart [port]          Restart the service (or built-in daemon)
+  claude-max-api status                  Show service + daemon status
+  claude-max-api logs [-f]               Print (or follow) the log file
+  claude-max-api mon [-n NUM]            Monitor recent requests (default 20, -1 = all)
+  claude-max-api help                    Show this help
 
 State files:
   pidfile: ${PID_FILE}
@@ -117,7 +122,65 @@ async function runForeground(port, registerPidFile) {
     process.on("SIGINT", shutdown);
     process.on("SIGTERM", shutdown);
 }
+/**
+ * Start the proxy.
+ *
+ * Preferred path: use the OS service (launchd / systemd user unit) that was
+ * registered at install time. If the service isn't installed yet but the
+ * platform supports one, auto-install it so the user never has to think about
+ * it — this matches `npm install -g`'s postinstall behavior but also covers
+ * the case where someone built from source.
+ *
+ * Fallback: if the platform has no service backend (rare: non-systemd Linux,
+ * Windows, etc.) fall back to the self-daemonize path.
+ */
 async function cmdStart(port) {
+    const platform = detectPlatform();
+    if (!platform) {
+        await cmdStartDaemon(port);
+        return;
+    }
+    if (!isInstalled()) {
+        console.log(`Installing service on ${platform}...`);
+        try {
+            installService(port);
+        }
+        catch (err) {
+            console.error(`install-service failed: ${err.message}`);
+            process.exit(1);
+        }
+        // RunAtLoad / enable --now already brought it up as part of install.
+        const info = await waitForPidFile().catch(() => null);
+        if (info) {
+            console.log(`Service started (pid ${info.pid}) on port ${info.port}.`);
+            console.log(`Logs: ${LOG_FILE}`);
+        }
+        else {
+            console.log(`Service installed. Use 'claude-max-api status' to verify.`);
+        }
+        return;
+    }
+    try {
+        startService();
+    }
+    catch (err) {
+        console.error(`start failed: ${err.message}`);
+        process.exit(1);
+    }
+    const info = await waitForPidFile(5000).catch(() => null);
+    if (info) {
+        console.log(`Service started (pid ${info.pid}) on port ${info.port}.`);
+        console.log(`Logs: ${LOG_FILE}`);
+    }
+    else {
+        console.log(`Service start requested. Use 'claude-max-api status' to verify.`);
+    }
+}
+/**
+ * Legacy self-daemonize path. Only invoked when the platform has no service
+ * backend (detectPlatform() returned null).
+ */
+async function cmdStartDaemon(port) {
     const existing = getRunningDaemon();
     if (existing) {
         console.error(`Server is already running (pid ${existing.pid}, port ${existing.port}). Use 'stop' or 'restart' first.`);
@@ -125,7 +188,7 @@ async function cmdStart(port) {
     }
     const scriptPath = fileURLToPath(import.meta.url);
     const childPid = daemonize(scriptPath, [String(port)]);
-    console.log(`Starting Claude Max API proxy in the background (initial pid ${childPid})...`);
+    console.log(`No service backend on this platform — starting Claude Max API proxy in the background (initial pid ${childPid})...`);
     try {
         const info = await waitForPidFile();
         console.log(`Server is running (pid ${info.pid}) on port ${info.port}.`);
@@ -137,36 +200,133 @@ async function cmdStart(port) {
     }
 }
 async function cmdStop() {
+    const platform = detectPlatform();
+    // Service path: ask launchd/systemd to stop the job. This SIGTERMs the
+    // running child, which triggers its shutdown handler and removes the
+    // pidfile on its own.
+    if (platform && isInstalled()) {
+        try {
+            stopService();
+        }
+        catch (err) {
+            console.error(`stop failed: ${err.message}`);
+            process.exit(1);
+        }
+        // Wait briefly for the pidfile to disappear so status feels synchronous.
+        const until = Date.now() + 5000;
+        while (Date.now() < until && getRunningDaemon()) {
+            await new Promise((r) => setTimeout(r, 100));
+        }
+        if (!getRunningDaemon()) {
+            removePidFile();
+            console.log("Service stopped.");
+        }
+        else {
+            console.log("Stop requested. Verify with 'claude-max-api status'.");
+        }
+        return;
+    }
+    // Legacy/fallback path: SIGTERM the pidfile-tracked daemon directly.
     const result = await stopDaemon();
     if (result.pid === null) {
-        console.log("No running server (no pidfile or stale pidfile).");
+        console.log("No running server (no service installed and no pidfile).");
         return;
     }
     if (result.stopped) {
-        console.log(`Stopped server (pid ${result.pid}).`);
+        console.log(`Stopped daemon (pid ${result.pid}).`);
     }
     else {
-        console.error(`Failed to stop server (pid ${result.pid}).`);
+        console.error(`Failed to stop daemon (pid ${result.pid}).`);
         process.exit(1);
     }
 }
 function cmdStatus() {
     const info = getRunningDaemon();
-    if (!info) {
-        console.log("Not running.");
-        // systemd-style "program not running" exit code, so shell scripts can
-        // distinguish "not running" from a real error like "permission denied".
-        process.exit(3);
+    const svc = serviceStatus();
+    if (svc.installed) {
+        console.log(`Service: installed (${svc.detail})`);
     }
-    console.log(`Running (pid ${info.pid}) on port ${info.port}, started ${info.startedAt}.`);
+    else {
+        const platform = detectPlatform();
+        console.log(platform
+            ? `Service: not installed (platform: ${platform})`
+            : `Service: unsupported platform (${process.platform})`);
+    }
+    if (info) {
+        console.log(`Process: running (pid ${info.pid}) on port ${info.port}, started ${info.startedAt}.`);
+        console.log(`Logs: ${LOG_FILE}`);
+        return;
+    }
+    console.log("Process: not running.");
     console.log(`Logs: ${LOG_FILE}`);
+    // systemd-style "program not running" exit code.
+    process.exit(3);
 }
 async function cmdRestart(port) {
+    const platform = detectPlatform();
+    if (platform && isInstalled()) {
+        try {
+            restartService();
+        }
+        catch (err) {
+            console.error(`restart failed: ${err.message}`);
+            process.exit(1);
+        }
+        const info = await waitForPidFile(5000).catch(() => null);
+        if (info) {
+            console.log(`Service restarted (pid ${info.pid}) on port ${info.port}.`);
+        }
+        else {
+            console.log("Service restart requested. Verify with 'claude-max-api status'.");
+        }
+        return;
+    }
+    // Fallback: stop the daemon (if any) and re-spawn via the legacy path.
     const result = await stopDaemon();
     if (result.stopped) {
-        console.log(`Stopped previous server (pid ${result.pid}).`);
+        console.log(`Stopped previous daemon (pid ${result.pid}).`);
     }
-    await cmdStart(port);
+    await cmdStartDaemon(port);
+    // Note on the port arg: changing port requires uninstall-service + reinstall
+    // on the service path, since the plist/unit bakes in the original port.
+    void port;
+}
+async function cmdInstallService(port) {
+    const platform = detectPlatform();
+    if (!platform) {
+        console.error(`No service backend available on ${process.platform}. Use 'claude-max-api start' for the built-in daemon.`);
+        process.exit(1);
+    }
+    const wasInstalled = isInstalled();
+    try {
+        installService(port);
+    }
+    catch (err) {
+        console.error(`install-service failed: ${err.message}`);
+        process.exit(1);
+    }
+    console.log(`Service ${wasInstalled ? "updated" : "installed"} on ${platform}, listening on port ${port}.`);
+    console.log("It will start automatically on login.");
+    console.log(`Logs: ${LOG_FILE}`);
+}
+function cmdUninstallService() {
+    const platform = detectPlatform();
+    if (!platform) {
+        console.log(`No service backend on ${process.platform}; nothing to uninstall.`);
+        return;
+    }
+    if (!isInstalled()) {
+        console.log("Service is not installed.");
+        return;
+    }
+    try {
+        uninstallService();
+    }
+    catch (err) {
+        console.error(`uninstall-service failed: ${err.message}`);
+        process.exit(1);
+    }
+    console.log("Service stopped and unit file removed.");
 }
 function cmdLogs(follow) {
     if (!fs.existsSync(LOG_FILE)) {
@@ -310,6 +470,12 @@ async function main() {
                 cmdLogs(follow);
                 return;
             }
+            case "install-service":
+                await cmdInstallService(parsePort(process.argv[3]));
+                return;
+            case "uninstall-service":
+                cmdUninstallService();
+                return;
             case "mon": {
                 // Parse -n NUMBER from remaining args
                 let monN = 20;

--- a/dist/subprocess/manager.d.ts
+++ b/dist/subprocess/manager.d.ts
@@ -27,7 +27,13 @@ export declare class ClaudeSubprocess extends EventEmitter {
      */
     start(prompt: string, options: SubprocessOptions): Promise<void>;
     /**
-     * Build CLI arguments array
+     * Build CLI arguments array.
+     *
+     * Note: neither the user prompt nor the system prompt is passed as argv —
+     * both are piped via stdin in start() (system prompt inlined as a labeled
+     * block at the top) to avoid E2BIG on long conversation histories or huge
+     * OpenClaw system prompts. claude --print reads stdin when no positional
+     * prompt is given.
      */
     private buildArgs;
     /**

--- a/dist/subprocess/manager.js
+++ b/dist/subprocess/manager.js
@@ -49,23 +49,48 @@ export class ClaudeSubprocess extends EventEmitter {
      * Start the Claude CLI subprocess with the given prompt
      */
     async start(prompt, options) {
-        const args = this.buildArgs(prompt, options);
+        const args = this.buildArgs(options);
+        // Inline the system prompt into stdin instead of passing it via
+        // --system-prompt. The OpenClaw system prompt can exceed 150 KB,
+        // which blows past Linux ARG_MAX (~128 KiB) and causes spawn E2BIG.
+        // Claude reliably follows instructions placed at the top of the
+        // user message inside a labeled block.
+        const stdinPayload = options.systemPrompt
+            ? `[System Instructions]\n${options.systemPrompt}\n[End System Instructions]\n\n${prompt}`
+            : prompt;
+        // Build the env we'll hand to spawn separately so we can measure it.
+        const childEnv = {
+            ...process.env,
+            CLAUDECODE: undefined,
+            // Ensure oc-tool is findable and can reach the gateway
+            PATH: [
+                path.join(process.env.HOME || "/tmp", ".openclaw", "bin"),
+                process.env.PATH ?? "/usr/local/bin:/usr/bin:/bin",
+            ].join(":"),
+            OPENCLAW_GATEWAY_TOKEN: resolveGatewayToken() ?? undefined,
+            OPENCLAW_GATEWAY_URL: process.env.OPENCLAW_GATEWAY_URL ?? "http://localhost:18789",
+        };
+        // Diagnostics: log argv + envp sizes so we can spot ARG_MAX (E2BIG) blowups.
+        // Linux ARG_MAX is typically 128 KiB and counts argv + envp combined.
+        const argvBytes = args.reduce((sum, a) => sum + Buffer.byteLength(a, "utf8") + 1, Buffer.byteLength("claude", "utf8") + 1);
+        const envpBytes = Object.entries(childEnv).reduce((sum, [k, v]) => {
+            if (v === undefined)
+                return sum;
+            return sum + Buffer.byteLength(`${k}=${v}`, "utf8") + 1;
+        }, 0);
+        const promptBytes = Buffer.byteLength(prompt, "utf8");
+        const sysPromptBytes = options.systemPrompt
+            ? Buffer.byteLength(options.systemPrompt, "utf8")
+            : 0;
+        const stdinBytes = Buffer.byteLength(stdinPayload, "utf8");
+        console.error(`[Subprocess] argv=${argvBytes}B envp=${envpBytes}B (sum=${argvBytes + envpBytes}B) ` +
+            `stdin=${stdinBytes}B (prompt=${promptBytes}B systemPrompt=${sysPromptBytes}B)`);
         return new Promise((resolve, reject) => {
             try {
                 // Use spawn() for security - no shell interpretation
                 this.process = spawn("claude", args, {
                     cwd: options.cwd || PROXY_CWD,
-                    env: {
-                        ...process.env,
-                        CLAUDECODE: undefined,
-                        // Ensure oc-tool is findable and can reach the gateway
-                        PATH: [
-                            path.join(process.env.HOME || "/tmp", ".openclaw", "bin"),
-                            process.env.PATH ?? "/usr/local/bin:/usr/bin:/bin",
-                        ].join(":"),
-                        OPENCLAW_GATEWAY_TOKEN: resolveGatewayToken() ?? undefined,
-                        OPENCLAW_GATEWAY_URL: process.env.OPENCLAW_GATEWAY_URL ?? "http://localhost:18789",
-                    },
+                    env: childEnv,
                     stdio: ["pipe", "pipe", "pipe"],
                 });
                 // Set activity timeout (resets on each stdout data)
@@ -81,9 +106,18 @@ export class ClaudeSubprocess extends EventEmitter {
                         reject(err);
                     }
                 });
-                // Close stdin since we pass prompt as argument
-                this.process.stdin?.end();
-                console.error(`[Subprocess] Process spawned with PID: ${this.process.pid}`);
+                // Pipe the prompt (and inlined system prompt) via stdin instead
+                // of argv to avoid E2BIG. Linux execve ARG_MAX is ~128 KiB and
+                // counts argv + envp combined; OpenClaw conversations + system
+                // prompts routinely exceed that on the command line.
+                const stdin = this.process.stdin;
+                if (stdin) {
+                    stdin.on("error", (err) => {
+                        console.error("[Subprocess] stdin error:", err.message);
+                    });
+                    stdin.end(stdinPayload, "utf8");
+                }
+                console.error(`[Subprocess] Process spawned with PID: ${this.process.pid} (${stdinBytes} bytes via stdin)`);
                 // Parse JSON stream from stdout
                 this.process.stdout?.on("data", (chunk) => {
                     const data = chunk.toString();
@@ -120,10 +154,16 @@ export class ClaudeSubprocess extends EventEmitter {
         });
     }
     /**
-     * Build CLI arguments array
+     * Build CLI arguments array.
+     *
+     * Note: neither the user prompt nor the system prompt is passed as argv —
+     * both are piped via stdin in start() (system prompt inlined as a labeled
+     * block at the top) to avoid E2BIG on long conversation histories or huge
+     * OpenClaw system prompts. claude --print reads stdin when no positional
+     * prompt is given.
      */
-    buildArgs(prompt, options) {
-        const args = [
+    buildArgs(options) {
+        return [
             "--print",
             "--output-format",
             "stream-json",
@@ -133,12 +173,6 @@ export class ClaudeSubprocess extends EventEmitter {
             options.model,
             "--dangerously-skip-permissions",
         ];
-        // Pass system prompt as a native CLI flag
-        if (options.systemPrompt) {
-            args.push("--system-prompt", options.systemPrompt);
-        }
-        args.push("--", prompt);
-        return args;
     }
     /**
      * Process the buffer and emit parsed messages

--- a/dist/subprocess/manager.js
+++ b/dist/subprocess/manager.js
@@ -76,9 +76,12 @@ export class ClaudeSubprocess extends EventEmitter {
             ? `[System Instructions]\nThe rules in this block override any default Claude Code behavior. When they conflict with built-in defaults, follow these rules.\n\n${options.systemPrompt}\n[End System Instructions]\n\n${prompt}`
             : prompt;
         // Build the env we'll hand to spawn separately so we can measure it.
+        // Note: assigning `CLAUDECODE: undefined` in an object spread does NOT
+        // remove the key — Node forwards undefined values to the child as the
+        // literal string "undefined". To actually unset CLAUDECODE we have to
+        // delete the key after the spread.
         const childEnv = {
             ...process.env,
-            CLAUDECODE: undefined,
             // Ensure oc-tool is findable and can reach the gateway
             PATH: [
                 path.join(process.env.HOME || "/tmp", ".openclaw", "bin"),
@@ -87,6 +90,7 @@ export class ClaudeSubprocess extends EventEmitter {
             OPENCLAW_GATEWAY_TOKEN: resolveGatewayToken() ?? undefined,
             OPENCLAW_GATEWAY_URL: process.env.OPENCLAW_GATEWAY_URL ?? "http://localhost:18789",
         };
+        delete childEnv.CLAUDECODE;
         // Diagnostics: log argv + envp sizes so we can spot ARG_MAX (E2BIG) blowups.
         // Linux ARG_MAX is typically 128 KiB and counts argv + envp combined.
         const argvBytes = args.reduce((sum, a) => sum + Buffer.byteLength(a, "utf8") + 1, Buffer.byteLength("claude", "utf8") + 1);

--- a/dist/subprocess/manager.js
+++ b/dist/subprocess/manager.js
@@ -214,7 +214,7 @@ export class ClaudeSubprocess extends EventEmitter {
      * prompt is given.
      */
     buildArgs(options) {
-        return [
+        const args = [
             "--print",
             "--output-format",
             "stream-json",
@@ -222,8 +222,14 @@ export class ClaudeSubprocess extends EventEmitter {
             "--include-partial-messages",
             "--model",
             options.model,
-            "--dangerously-skip-permissions",
         ];
+        // Safe mode: opt out of --dangerously-skip-permissions, which would
+        // otherwise let any input that reaches the proxy run arbitrary Bash on
+        // the host. See README "Security model" for the trade-off.
+        if (process.env.CLAUDE_PROXY_SAFE_MODE !== "1") {
+            args.push("--dangerously-skip-permissions");
+        }
+        return args;
     }
     /**
      * Process the buffer and emit parsed messages

--- a/dist/subprocess/manager.js
+++ b/dist/subprocess/manager.js
@@ -86,6 +86,14 @@ export class ClaudeSubprocess extends EventEmitter {
         console.error(`[Subprocess] argv=${argvBytes}B envp=${envpBytes}B (sum=${argvBytes + envpBytes}B) ` +
             `stdin=${stdinBytes}B (prompt=${promptBytes}B systemPrompt=${sysPromptBytes}B)`);
         return new Promise((resolve, reject) => {
+            // Settle once: we either resolve on the spawn handshake or reject
+            // on a spawn error, but never both. After the start() promise has
+            // resolved, any further child errors are surfaced as ClaudeSubprocess
+            // 'error' events instead so consumers can handle them in-stream.
+            let settled = false;
+            const wrapSpawnError = (err) => err.message.includes("ENOENT")
+                ? new Error("Claude CLI not found. Install with: npm install -g @anthropic-ai/claude-code")
+                : err;
             try {
                 // Use spawn() for security - no shell interpretation
                 this.process = spawn("claude", args, {
@@ -96,14 +104,31 @@ export class ClaudeSubprocess extends EventEmitter {
                 // Set activity timeout (resets on each stdout data)
                 this.activityTimeout = ACTIVITY_TIMEOUT;
                 this.resetActivityTimeout();
-                // Handle spawn errors (e.g., claude not found)
+                // The 'spawn' event fires once the child has actually been
+                // forked. Defer resolving start() until then so async spawn
+                // errors (e.g. ENOENT) reach the caller as a real rejection
+                // instead of being silently swallowed by an already-resolved
+                // promise.
+                this.process.once("spawn", () => {
+                    if (settled)
+                        return;
+                    settled = true;
+                    console.error(`[Subprocess] Process spawned with PID: ${this.process?.pid} (${stdinBytes} bytes via stdin)`);
+                    resolve();
+                });
+                // Handle child errors. Before the start() promise has settled,
+                // surface them as a rejection so the HTTP layer can produce a
+                // proper 5xx. After settling, re-emit them so streaming
+                // consumers can react in-band.
                 this.process.on("error", (err) => {
-                    this.clearTimeout();
-                    if (err.message.includes("ENOENT")) {
-                        reject(new Error("Claude CLI not found. Install with: npm install -g @anthropic-ai/claude-code"));
+                    const wrapped = wrapSpawnError(err);
+                    if (!settled) {
+                        settled = true;
+                        this.clearTimeout();
+                        reject(wrapped);
                     }
                     else {
-                        reject(err);
+                        this.emit("error", wrapped);
                     }
                 });
                 // Pipe the prompt (and inlined system prompt) via stdin instead
@@ -117,7 +142,6 @@ export class ClaudeSubprocess extends EventEmitter {
                     });
                     stdin.end(stdinPayload, "utf8");
                 }
-                console.error(`[Subprocess] Process spawned with PID: ${this.process.pid} (${stdinBytes} bytes via stdin)`);
                 // Parse JSON stream from stdout
                 this.process.stdout?.on("data", (chunk) => {
                     const data = chunk.toString();
@@ -144,12 +168,14 @@ export class ClaudeSubprocess extends EventEmitter {
                     }
                     this.emit("close", code);
                 });
-                // Resolve immediately since we're streaming
-                resolve();
             }
             catch (err) {
-                this.clearTimeout();
-                reject(err);
+                // Synchronous spawn failures (e.g. EACCES, E2BIG) end up here.
+                if (!settled) {
+                    settled = true;
+                    this.clearTimeout();
+                    reject(err);
+                }
             }
         });
     }

--- a/dist/subprocess/manager.js
+++ b/dist/subprocess/manager.js
@@ -38,7 +38,17 @@ function resolveGatewayToken() {
     }
     return _gatewayToken;
 }
-const ACTIVITY_TIMEOUT = 600_000; // 10 minutes (no stdout activity = stuck)
+// Activity watchdog: if the CLI emits nothing on stdout *or* stderr for
+// this many milliseconds, we assume it is wedged and SIGTERM it. The default
+// is 10 minutes; tune via env for unusually long-running tools.
+const DEFAULT_ACTIVITY_TIMEOUT = 600_000;
+const ACTIVITY_TIMEOUT = (() => {
+    const raw = process.env.CLAUDE_PROXY_ACTIVITY_TIMEOUT_MS;
+    if (!raw)
+        return DEFAULT_ACTIVITY_TIMEOUT;
+    const parsed = parseInt(raw, 10);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_ACTIVITY_TIMEOUT;
+})();
 export class ClaudeSubprocess extends EventEmitter {
     process = null;
     buffer = "";
@@ -158,8 +168,12 @@ export class ClaudeSubprocess extends EventEmitter {
                     this.buffer += data;
                     this.processBuffer();
                 });
-                // Capture stderr for debugging
+                // Capture stderr for debugging. stderr output also counts as
+                // activity — if the CLI is producing progress logs (or even
+                // tool execution traces) on stderr while waiting on something
+                // expensive, we should not kill it just because stdout is idle.
                 this.process.stderr?.on("data", (chunk) => {
+                    this.resetActivityTimeout();
                     const errorText = chunk.toString().trim();
                     if (errorText) {
                         console.error("[Subprocess stderr]:", errorText.slice(0, 500));

--- a/dist/subprocess/manager.js
+++ b/dist/subprocess/manager.js
@@ -55,8 +55,15 @@ export class ClaudeSubprocess extends EventEmitter {
         // which blows past Linux ARG_MAX (~128 KiB) and causes spawn E2BIG.
         // Claude reliably follows instructions placed at the top of the
         // user message inside a labeled block.
+        //
+        // Because we no longer use --system-prompt, Claude Code's built-in
+        // system prompt is still in effect. The override banner tells the
+        // model that anything inside the [System Instructions] block takes
+        // precedence over default Claude Code behavior, so OpenClaw rules
+        // (e.g. "always reply in Chinese", "never use Bash for X") still
+        // win when they conflict with the default agent behavior.
         const stdinPayload = options.systemPrompt
-            ? `[System Instructions]\n${options.systemPrompt}\n[End System Instructions]\n\n${prompt}`
+            ? `[System Instructions]\nThe rules in this block override any default Claude Code behavior. When they conflict with built-in defaults, follow these rules.\n\n${options.systemPrompt}\n[End System Instructions]\n\n${prompt}`
             : prompt;
         // Build the env we'll hand to spawn separately so we can measure it.
         const childEnv = {

--- a/dist/subprocess/manager.js
+++ b/dist/subprocess/manager.js
@@ -249,7 +249,11 @@ export class ClaudeSubprocess extends EventEmitter {
                 }
             }
             catch {
-                // Non-JSON output, emit as raw
+                // The CLI usually emits stream-json on stdout, but if it ever
+                // dumps a non-JSON line (panic stack trace, "Sandbox violation:",
+                // permission prompt) we surface it instead of silently
+                // swallowing it via the unconsumed 'raw' event.
+                console.error("[Subprocess] Non-JSON stdout line:", trimmed.slice(0, 500));
                 this.emit("raw", trimmed);
             }
         }

--- a/docs/macos-setup.md
+++ b/docs/macos-setup.md
@@ -1,120 +1,68 @@
 # macOS Auto-Start Setup
 
-This guide shows how to configure the Claude Code CLI Provider to start automatically when you log in.
+As of v1.4, auto-start is handled by `claude-max-api install-service`, which
+is invoked automatically by the global npm install.
 
-## Create LaunchAgent
-
-1. Create the plist file:
-
-```bash
-cat > ~/Library/LaunchAgents/com.claude-code-provider.plist << 'PLIST'
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-  <dict>
-    <key>Label</key>
-    <string>com.claude-code-provider</string>
-    
-    <key>Comment</key>
-    <string>Claude Code CLI Provider (uses Claude Max subscription)</string>
-    
-    <key>RunAtLoad</key>
-    <true/>
-    
-    <key>KeepAlive</key>
-    <true/>
-    
-    <key>ProgramArguments</key>
-    <array>
-      <string>/opt/homebrew/bin/node</string>
-      <string>/path/to/claude-code-cli-provider/dist/server/standalone.js</string>
-    </array>
-    
-    <key>StandardOutPath</key>
-    <string>/tmp/claude-provider.log</string>
-    
-    <key>StandardErrorPath</key>
-    <string>/tmp/claude-provider.err.log</string>
-    
-    <key>EnvironmentVariables</key>
-    <dict>
-      <key>HOME</key>
-      <string>/Users/YOUR_USERNAME</string>
-      <key>PATH</key>
-      <string>/Users/YOUR_USERNAME/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
-    </dict>
-  </dict>
-</plist>
-PLIST
-```
-
-2. **Important:** Edit the file and replace:
-   - `/path/to/claude-code-cli-provider` with your actual path
-   - `/Users/YOUR_USERNAME` with your actual username
-   - Ensure the PATH includes the directory containing `claude` (check with `which claude`)
-
-## Load the Service
+## Install
 
 ```bash
-# Load and start the service
-launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.claude-code-provider.plist
-
-# Verify it's running
-launchctl list | grep claude-code
-curl http://localhost:3456/health
+npm install -g claude-max-api-proxy
 ```
 
-## Management Commands
+The post-install hook writes `~/Library/LaunchAgents/com.claude-max-api.plist`
+and loads it into your user's `gui/<uid>` launchd domain. `RunAtLoad` + a
+conditional `KeepAlive` (`SuccessfulExit=false`) means it starts on login and
+restarts on crash, but stays down after a deliberate `claude-max-api stop`.
+
+## Manage
 
 ```bash
-# Check status
-launchctl list | grep claude-code
-
-# Restart the service
-launchctl kickstart -k gui/$(id -u)/com.claude-code-provider
-
-# Stop the service (temporary)
-launchctl bootout gui/$(id -u)/com.claude-code-provider
-
-# Start the service again
-launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.claude-code-provider.plist
-
-# View logs
-tail -f /tmp/claude-provider.log
-tail -f /tmp/claude-provider.err.log
+claude-max-api status              # loaded + running?
+claude-max-api stop                # launchctl bootout
+claude-max-api start               # launchctl bootstrap (or kickstart)
+claude-max-api restart             # launchctl kickstart -k
+claude-max-api logs -f             # tail the service log
 ```
+
+Logs go to `~/.claude-max-api/proxy.log` (stdout + stderr merged).
+
+## Change the port
+
+```bash
+claude-max-api install-service 3457
+```
+
+That rewrites the plist with the new port and reloads the service. No manual
+plist editing needed.
 
 ## Uninstall
 
 ```bash
-# Stop and remove the service
-launchctl bootout gui/$(id -u)/com.claude-code-provider
-rm ~/Library/LaunchAgents/com.claude-code-provider.plist
+claude-max-api uninstall-service
+# or, to remove the whole package:
+npm uninstall -g claude-max-api-proxy
 ```
+
+> `npm uninstall -g` does **not** reliably run pre-uninstall hooks, so run
+> `uninstall-service` first if you want to be sure the LaunchAgent is gone
+> before the binary disappears.
 
 ## Troubleshooting
 
-### Service starts but health check fails
+Tail the log and check service state:
 
-Check the error log:
 ```bash
-cat /tmp/claude-provider.err.log
+claude-max-api logs -f
+claude-max-api status
+launchctl print "gui/$(id -u)/com.claude-max-api"
 ```
 
 Common issues:
-- Wrong path to `standalone.js`
-- `claude` CLI not in PATH
-- Node.js not found
-
-### Finding the right paths
-
-```bash
-# Find node
-which node
-
-# Find claude
-which claude
-
-# Your home directory
-echo $HOME
-```
+- **`claude: command not found` in logs** — the service inherits a minimal
+  PATH. `install-service` seeds common locations (`/opt/homebrew/bin`,
+  `/usr/local/bin`, `~/.npm-global/bin`, `~/.nvm/...`), but if yours is
+  somewhere else, re-run `install-service` with the desired `PATH` exported
+  in your current shell — it's captured at install time.
+- **Not starting on login over SSH** — LaunchAgents in the `gui/<uid>`
+  domain require a GUI session. SSH-only Macs should use a plain
+  `claude-max-api start` in a tmux/`at`-scheduled login shell instead.

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "start": "node dist/server/standalone.js",
     "test": "node --test dist/**/*.test.js",
     "clean": "rm -rf dist",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "npm run build",
+    "postinstall": "node -e \"const fs=require('node:fs');if(fs.existsSync('dist/server/install-service.js')){require('node:child_process').spawnSync(process.execPath,['dist/server/install-service.js','--auto'],{stdio:'inherit'});}\""
   },
   "keywords": [
     "claude",

--- a/src/adapter/cli-to-openai.test.ts
+++ b/src/adapter/cli-to-openai.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Unit tests for the Claude CLI → OpenAI adapter pure functions.
+ * Run with: npm test
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { parseToolCalls } from "./cli-to-openai.js";
+
+test("parseToolCalls: extracts a single well-formed tool call", () => {
+    const text = `prelude\n<tool_call>{"id":"call_1","name":"get_weather","arguments":{"city":"Tokyo"}}</tool_call>\ntrailer`;
+    const result = parseToolCalls(text);
+    assert.equal(result.hasToolCalls, true);
+    assert.equal(result.toolCalls.length, 1);
+    assert.equal(result.toolCalls[0].id, "call_1");
+    assert.equal(result.toolCalls[0].function.name, "get_weather");
+    // arguments must be a JSON string per OpenAI spec
+    assert.equal(typeof result.toolCalls[0].function.arguments, "string");
+    assert.equal(result.toolCalls[0].function.arguments, '{"city":"Tokyo"}');
+});
+
+test("parseToolCalls: extracts multiple tool calls in order", () => {
+    const text =
+        `<tool_call>{"id":"call_a","name":"a","arguments":{}}</tool_call>` +
+        `\n<tool_call>{"id":"call_b","name":"b","arguments":{"x":1}}</tool_call>`;
+    const result = parseToolCalls(text);
+    assert.equal(result.toolCalls.length, 2);
+    assert.equal(result.toolCalls[0].id, "call_a");
+    assert.equal(result.toolCalls[1].id, "call_b");
+    assert.equal(result.toolCalls[1].function.arguments, '{"x":1}');
+});
+
+test("parseToolCalls: arguments already as a string is preserved verbatim", () => {
+    const text = `<tool_call>{"id":"call_1","name":"a","arguments":"{\\"raw\\":true}"}</tool_call>`;
+    const result = parseToolCalls(text);
+    assert.equal(result.toolCalls[0].function.arguments, '{"raw":true}');
+});
+
+test("parseToolCalls: ignores malformed JSON inside tool_call without crashing", () => {
+    const text = `<tool_call>not actually json</tool_call> trailing prose`;
+    const result = parseToolCalls(text);
+    // Malformed call is silently dropped, but the surrounding text still loses the marker
+    assert.equal(result.hasToolCalls, false);
+    assert.equal(result.textWithoutToolCalls, "trailing prose");
+});
+
+test("parseToolCalls: text without markers passes through unchanged", () => {
+    const text = "Just a normal answer.";
+    const result = parseToolCalls(text);
+    assert.equal(result.hasToolCalls, false);
+    assert.equal(result.toolCalls.length, 0);
+    assert.equal(result.textWithoutToolCalls, "Just a normal answer.");
+});
+
+test("parseToolCalls: concurrent invocations do not share state", () => {
+    // Regression for the previous module-level /g RegExp lastIndex bug.
+    // Run a long parse and a short parse interleaved and check both finish
+    // with the right results.
+    const longText = `<tool_call>{"id":"long","name":"l","arguments":{"k":"${"v".repeat(1000)}"}}</tool_call>`;
+    const shortText = `<tool_call>{"id":"short","name":"s","arguments":{}}</tool_call>`;
+    const a = parseToolCalls(longText);
+    const b = parseToolCalls(shortText);
+    const c = parseToolCalls(longText);
+    assert.equal(a.toolCalls[0].id, "long");
+    assert.equal(b.toolCalls[0].id, "short");
+    assert.equal(c.toolCalls[0].id, "long");
+});

--- a/src/adapter/cli-to-openai.ts
+++ b/src/adapter/cli-to-openai.ts
@@ -10,8 +10,6 @@ import type {
 
 // ─── Tool call parsing ──────────────────────────────────────────────
 
-const TOOL_CALL_RE = /<tool_call>([\s\S]*?)<\/tool_call>/g;
-
 export interface ParsedToolCallResult {
     hasToolCalls: boolean;
     toolCalls: OpenAIToolCall[];
@@ -31,10 +29,11 @@ export interface ParsedToolCallResult {
  */
 export function parseToolCalls(text: string): ParsedToolCallResult {
     const toolCalls: OpenAIToolCall[] = [];
-    // Reset lastIndex since the regex is module-level with /g flag
-    TOOL_CALL_RE.lastIndex = 0;
+    // Local regex instance: a module-level /g RegExp shares lastIndex across
+    // all callers, which is unsafe under concurrent requests.
+    const re = /<tool_call>([\s\S]*?)<\/tool_call>/g;
 
-    const textWithoutToolCalls = text.replace(TOOL_CALL_RE, (_, inner) => {
+    const textWithoutToolCalls = text.replace(re, (_, inner) => {
         try {
             const parsed = JSON.parse(inner.trim());
             const args = parsed.arguments;

--- a/src/adapter/openai-to-cli.test.ts
+++ b/src/adapter/openai-to-cli.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Unit tests for the OpenAI → Claude CLI adapter pure functions.
+ * Run with: npm test
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+    extractModel,
+    messagesToPrompt,
+    stripAssistantBleed,
+} from "./openai-to-cli.js";
+
+// ── extractModel ───────────────────────────────────────────────────
+
+test("extractModel: bare aliases pass through", () => {
+    assert.equal(extractModel("opus"), "opus");
+    assert.equal(extractModel("sonnet"), "sonnet");
+    assert.equal(extractModel("haiku"), "haiku");
+});
+
+test("extractModel: provider prefix is stripped before lookup", () => {
+    assert.equal(extractModel("maxproxy/claude-opus-4"), "opus");
+    assert.equal(extractModel("claude-code-cli/claude-sonnet-4-6"), "sonnet");
+});
+
+test("extractModel: opus minor versions resolve to dated names", () => {
+    assert.equal(extractModel("claude-opus-4-5"), "claude-opus-4-5-20251101");
+    assert.equal(extractModel("claude-opus-4-1"), "claude-opus-4-1-20250805");
+    assert.equal(extractModel("claude-opus-4-0"), "claude-opus-4-20250514");
+});
+
+test("extractModel: sonnet variants collapse to alias", () => {
+    assert.equal(extractModel("claude-sonnet-4"), "sonnet");
+    assert.equal(extractModel("claude-sonnet-4-5"), "sonnet");
+});
+
+test("extractModel: empty / unknown defaults to opus", () => {
+    assert.equal(extractModel(""), "opus");
+    assert.equal(extractModel("gpt-4o"), "opus");
+});
+
+// ── stripAssistantBleed ────────────────────────────────────────────
+
+test("stripAssistantBleed: cuts at first \\n[User] sentinel", () => {
+    const input = "Here is the answer.\n[User]\nNext turn?";
+    assert.equal(stripAssistantBleed(input), "Here is the answer.");
+});
+
+test("stripAssistantBleed: handles \\nHuman: legacy format", () => {
+    const input = "Done.\nHuman: another question";
+    assert.equal(stripAssistantBleed(input), "Done.");
+});
+
+test("stripAssistantBleed: leaves clean text untouched", () => {
+    const input = "Just a normal reply with no sentinels.";
+    assert.equal(stripAssistantBleed(input), input);
+});
+
+test("stripAssistantBleed: cuts at the earliest sentinel when multiple appear", () => {
+    const input = "ok\nHuman: q1\n[User]\nq2";
+    assert.equal(stripAssistantBleed(input), "ok");
+});
+
+// ── messagesToPrompt ───────────────────────────────────────────────
+
+test("messagesToPrompt: renders user/assistant turns with [User]/[Assistant] tags", () => {
+    const prompt = messagesToPrompt([
+        { role: "user", content: "Hello" },
+        { role: "assistant", content: "Hi there" },
+        { role: "user", content: "Why?" },
+    ]);
+    assert.match(prompt, /\[User\]\nHello/);
+    assert.match(prompt, /\[Assistant\]\nHi there/);
+    assert.match(prompt, /\[User\]\nWhy\?$/);
+});
+
+test("messagesToPrompt: drops NO_REPLY assistant messages", () => {
+    const prompt = messagesToPrompt([
+        { role: "user", content: "ping" },
+        { role: "assistant", content: "NO_REPLY" },
+        { role: "user", content: "are you there?" },
+    ]);
+    assert.doesNotMatch(prompt, /NO_REPLY/);
+    assert.match(prompt, /are you there\?/);
+});
+
+test("messagesToPrompt: array content of {type:'text'} blocks is flattened", () => {
+    const prompt = messagesToPrompt([
+        {
+            role: "user",
+            content: [
+                { type: "text", text: "first" },
+                { type: "text", text: "second" },
+            ],
+        },
+    ]);
+    assert.match(prompt, /\[User\]\nfirst\nsecond/);
+});
+
+test("messagesToPrompt: truncates oldest history when over byte budget", () => {
+    // Force the smallest possible budget for this test by overriding the env
+    // var BEFORE re-importing? We can't easily do that with a static import.
+    // Instead, build a 200 KiB conversation and assume the default 100 KiB
+    // budget kicks in.
+    const big = "x".repeat(20_000);
+    const messages = Array.from({ length: 8 }, (_, i) => ({
+        role: "user" as const,
+        content: `turn ${i}: ${big}`,
+    }));
+    // Final message we expect to always survive
+    messages.push({ role: "user" as const, content: "FINAL_MARKER" });
+
+    const prompt = messagesToPrompt(messages);
+    assert.match(prompt, /FINAL_MARKER/);
+    assert.match(prompt, /earlier messages truncated/);
+    // The very first turn (turn 0) should have been dropped
+    assert.doesNotMatch(prompt, /turn 0:/);
+});

--- a/src/adapter/openai-to-cli.ts
+++ b/src/adapter/openai-to-cli.ts
@@ -21,7 +21,12 @@ export interface CliInput {
  */
 function extractText(content: OpenAIChatMessage["content"]): string {
     if (content === null || content === undefined) return "";
-    if (typeof content === "string") return content;
+    if (typeof content === "string") {
+        // Some upstream serializers stringify null content as the literal
+        // four-letter word "null". Treat that as empty so callers don't
+        // need a separate guard.
+        return content === "null" ? "" : content;
+    }
     if (Array.isArray(content)) {
         return content
             .filter((c) => c.type === "text" && typeof c.text === "string")
@@ -537,7 +542,7 @@ export function messagesToPrompt(
                 }
 
                 // Skip assistant messages that are purely tool_calls with no text
-                if (msg.tool_calls && (!text || text === "null")) break;
+                if (msg.tool_calls && !text) break;
                 // Clean XML tool patterns to prevent CLI from mimicking them
                 const cleaned = cleanAssistantContent(text);
                 if (cleaned) {

--- a/src/adapter/openai-to-cli.ts
+++ b/src/adapter/openai-to-cli.ts
@@ -501,75 +501,150 @@ export function extractSystemPrompt(
  *   tool role messages (tool results) are rendered as [Tool Result:] blocks.
  *   When false, both are skipped (CLI handles tools internally).
  */
+/**
+ * Default soft cap on the rendered prompt size, in UTF-8 bytes. The proxy
+ * pipes the prompt via stdin so we are not bound by ARG_MAX (~128 KiB) any
+ * more, but very long histories still cost input tokens linearly *and*
+ * compound across every request because the gateway resends the full
+ * history each turn. Cap conservatively and let the user override.
+ */
+const DEFAULT_PROMPT_BUDGET_BYTES = 100_000;
+const PROMPT_BUDGET_BYTES = (() => {
+    const raw = process.env.CLAUDE_PROXY_PROMPT_BUDGET_BYTES;
+    if (!raw) return DEFAULT_PROMPT_BUDGET_BYTES;
+    const parsed = parseInt(raw, 10);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_PROMPT_BUDGET_BYTES;
+})();
+
+const TRUNCATION_NOTE = "[earlier messages truncated due to length]";
+
+/**
+ * Render a single non-system message into its prompt-block string, or
+ * return null if the message has nothing to contribute (NO_REPLY filler,
+ * empty assistant tool_calls, ignored tool results, etc.).
+ */
+function renderMessage(
+    msg: OpenAIChatMessage,
+    hasExternalTools: boolean,
+): string | null {
+    const text = extractText(msg.content);
+
+    switch (msg.role) {
+        case "user":
+            return `[User]\n${text}`;
+
+        case "assistant": {
+            // Skip NO_REPLY responses — OpenClaw silent tokens, not real content
+            if (!text || text.trim() === "NO_REPLY") {
+                if (hasExternalTools && msg.tool_calls && msg.tool_calls.length > 0) {
+                    // fall through to tool-call rendering below
+                } else {
+                    return null;
+                }
+            }
+
+            if (hasExternalTools && msg.tool_calls && msg.tool_calls.length > 0) {
+                // Render prior tool calls as text markers so the model understands
+                // what it previously requested (multi-turn tool conversation)
+                const markers = msg.tool_calls
+                    .map((tc) => {
+                        const args = typeof tc.function.arguments === "string"
+                            ? tc.function.arguments
+                            : JSON.stringify(tc.function.arguments);
+                        let argsObj: unknown;
+                        try { argsObj = JSON.parse(args); } catch { argsObj = args; }
+                        return `<tool_call>${JSON.stringify({
+                            id: tc.id,
+                            name: tc.function.name,
+                            arguments: argsObj,
+                        })}</tool_call>`;
+                    })
+                    .join("\n");
+                return `[Assistant]\n${markers}`;
+            }
+
+            // Skip assistant messages that are purely tool_calls with no text
+            if (msg.tool_calls && !text) return null;
+            // Clean XML tool patterns to prevent CLI from mimicking them
+            const cleaned = cleanAssistantContent(text);
+            return cleaned ? `[Assistant]\n${cleaned}` : null;
+        }
+
+        case "tool": {
+            if (!hasExternalTools) return null;
+            const label = msg.tool_call_id
+                ? `Tool Result: ${msg.tool_call_id}${msg.name ? ` (${msg.name})` : ""}`
+                : `Tool Result`;
+            return `[${label}]\n${text}`;
+        }
+
+        default:
+            return text || null;
+    }
+}
+
+/**
+ * Convert OpenAI messages array to a single prompt string for Claude CLI.
+ *
+ * Claude Code CLI in --print mode expects a single prompt, not a conversation.
+ * System messages are extracted separately (see extractSystemPrompt). XML tool
+ * patterns in assistant messages are cleaned by cleanAssistantContent() to
+ * prevent the model from mimicking XML format instead of using native tools.
+ * NO_REPLY assistant messages are filtered out (OpenClaw silent reply tokens).
+ *
+ * If the rendered prompt exceeds PROMPT_BUDGET_BYTES, the oldest messages
+ * are dropped (the most recent message is always retained) and a truncation
+ * marker is prepended.
+ *
+ * @param hasExternalTools - When true, assistant messages with tool_calls are
+ *   rendered as <tool_call> markers (for multi-turn tool conversations), and
+ *   tool role messages (tool results) are rendered as [Tool Result:] blocks.
+ *   When false, both are skipped (CLI handles tools internally).
+ */
 export function messagesToPrompt(
     messages: OpenAIChatMessage[],
     hasExternalTools = false
 ): string {
     const nonSystemMessages = messages.filter((msg) => msg.role !== "system");
     const parts: string[] = [];
-
     for (const msg of nonSystemMessages) {
-        const text = extractText(msg.content);
-
-        switch (msg.role) {
-            case "user":
-                parts.push(`[User]\n${text}`);
-                break;
-
-            case "assistant": {
-                // Skip NO_REPLY responses — OpenClaw silent tokens, not real content
-                if (!text || text.trim() === "NO_REPLY") break;
-
-                if (hasExternalTools && msg.tool_calls && msg.tool_calls.length > 0) {
-                    // Render prior tool calls as text markers so the model understands
-                    // what it previously requested (multi-turn tool conversation)
-                    const markers = msg.tool_calls
-                        .map((tc) => {
-                            const args = typeof tc.function.arguments === "string"
-                                ? tc.function.arguments
-                                : JSON.stringify(tc.function.arguments);
-                            let argsObj: unknown;
-                            try { argsObj = JSON.parse(args); } catch { argsObj = args; }
-                            return `<tool_call>${JSON.stringify({
-                                id: tc.id,
-                                name: tc.function.name,
-                                arguments: argsObj,
-                            })}</tool_call>`;
-                        })
-                        .join("\n");
-                    parts.push(`[Assistant]\n${markers}`);
-                    break;
-                }
-
-                // Skip assistant messages that are purely tool_calls with no text
-                if (msg.tool_calls && !text) break;
-                // Clean XML tool patterns to prevent CLI from mimicking them
-                const cleaned = cleanAssistantContent(text);
-                if (cleaned) {
-                    parts.push(`[Assistant]\n${cleaned}`);
-                }
-                break;
-            }
-
-            case "tool": {
-                if (hasExternalTools) {
-                    // Render tool results so the model receives the outcome
-                    const label = msg.tool_call_id
-                        ? `Tool Result: ${msg.tool_call_id}${msg.name ? ` (${msg.name})` : ""}`
-                        : `Tool Result`;
-                    parts.push(`[${label}]\n${text}`);
-                }
-                // When not using external tools, skip (CLI has its own tool system)
-                break;
-            }
-
-            default:
-                parts.push(text);
-                break;
-        }
+        const part = renderMessage(msg, hasExternalTools);
+        if (part) parts.push(part);
     }
 
-    return parts.join("\n\n").trim();
+    if (parts.length === 0) return "";
+
+    const SEPARATOR = "\n\n";
+    const sepBytes = Buffer.byteLength(SEPARATOR, "utf8");
+    const partBytes = parts.map((p) => Buffer.byteLength(p, "utf8"));
+    let totalBytes = partBytes.reduce(
+        (sum, b, i) => sum + b + (i > 0 ? sepBytes : 0),
+        0,
+    );
+
+    if (totalBytes <= PROMPT_BUDGET_BYTES) {
+        return parts.join(SEPARATOR).trim();
+    }
+
+    // Over budget — drop the oldest parts one at a time, but always keep
+    // the most recent message (that is the actual user turn the model
+    // needs to answer). Surface the truncation in the prompt itself so the
+    // model knows context was clipped.
+    const truncationBytes = Buffer.byteLength(TRUNCATION_NOTE, "utf8") + sepBytes;
+    let dropFrom = 0;
+    while (dropFrom < parts.length - 1 && totalBytes + truncationBytes > PROMPT_BUDGET_BYTES) {
+        totalBytes -= partBytes[dropFrom] + sepBytes;
+        dropFrom += 1;
+    }
+
+    if (dropFrom > 0) {
+        console.error(
+            `[messagesToPrompt] Truncated ${dropFrom} oldest message(s) ` +
+                `to fit ${PROMPT_BUDGET_BYTES}-byte budget`,
+        );
+    }
+
+    return [TRUNCATION_NOTE, ...parts.slice(dropFrom)].join(SEPARATOR).trim();
 }
 
 // ─── Stop-sequence bleed stripping ────────────────────────────────

--- a/src/adapter/openai-to-cli.ts
+++ b/src/adapter/openai-to-cli.ts
@@ -229,8 +229,18 @@ export function extractModel(model: string): ClaudeModel {
 
 /**
  * CLI tool usage instruction appended to the system prompt.
- * This ensures the CLI model uses its native tool system (Bash, Read, Write, etc.)
- * instead of outputting XML-formatted tool calls as text.
+ *
+ * This is the *minimum* set of rules the proxy depends on:
+ *  1. Use native CLI tools, never XML stand-ins.
+ *  2. Always actually transcribe audio rather than hallucinate.
+ *  3. The MEDIA: / FILE: / [[…]] response directives the proxy parses.
+ *  4. The 10-minute activity-timeout escape hatch.
+ *  5. Final-response formatting (target language, no internal thinking).
+ *
+ * Detailed oc-tool subcommand usage used to be documented inline here, but
+ * that bloated every request by 4-5 KiB of input tokens and was constantly
+ * out of date. The model can rediscover it on demand via `oc-tool --help`
+ * (and `oc-tool <subcommand> --help`), since it has Bash anyway.
  */
 const CLI_TOOL_INSTRUCTION = `
 
@@ -254,109 +264,26 @@ When you receive a voice/audio message (indicated by [media attached: ...ogg] or
 - Transcribe directly with: curl -s -X POST "https://api.groq.com/openai/v1/audio/transcriptions" -H "Authorization: Bearer $GROQ_API_KEY" -H "Content-Type: multipart/form-data" -F "file=@/path/to/file.ogg" -F "model=whisper-large-v3-turbo" -F "language=zh"
 - If transcription fails, say so honestly — do NOT make up a transcription
 
-## OpenClaw Tools (via oc-tool)
-Use \`oc-tool\` in Bash for OpenClaw platform operations. Args are always JSON.
+## OpenClaw Platform Tools (via oc-tool in Bash)
+\`oc-tool\` is on PATH. It exposes the OpenClaw platform: cross-channel
+messaging (telegram/slack/discord), browser automation, cron, sessions,
+TTS, web search/fetch, image analysis, and more. All arguments are JSON.
 
-### Browser
-  oc-tool browser status                                      # connection status
-  oc-tool browser tabs                                        # list open tabs
-  oc-tool browser tab new                                     # open new tab
-  oc-tool browser tab select 2                                # switch to tab 2
-  oc-tool browser tab close 2                                 # close tab 2
-  oc-tool browser navigate https://example.com                # go to URL
-  oc-tool browser snapshot                                    # accessibility tree (returns refs like e6, e12)
-  oc-tool browser snapshot --interactive --compact            # interactive elements only, compact
-  oc-tool browser snapshot --selector "#main" --interactive   # scoped to a CSS selector
-  oc-tool browser screenshot                                  # capture page image (returns MEDIA: path)
-  oc-tool browser screenshot --full-page                      # full page screenshot
-  oc-tool browser pdf                                         # render page as PDF (returns MEDIA: path)
-  oc-tool browser console --level error                       # get console errors
-  oc-tool browser click e12                                   # click element by ref
-  oc-tool browser click e12 --double                          # double-click
-  oc-tool browser type e3 "hello" --submit                    # type text, press Enter after
-  oc-tool browser press Enter                                 # press a key (Enter, Tab, Escape, etc.)
-  oc-tool browser hover e44                                   # hover over element
-  oc-tool browser drag e10 e11                                # drag from one ref to another
-  oc-tool browser select e9 OptionA OptionB                   # select dropdown options
-  oc-tool browser fill --fields '[{"ref":"e1","type":"text","value":"Ada"}]'  # fill multiple fields
-  oc-tool browser evaluate --fn '(el) => el.textContent' --ref e7             # run JS on element
-  oc-tool browser upload /tmp/file.pdf                        # upload file to active input
-  oc-tool browser dialog --accept                             # accept JS alert/confirm/prompt
-  oc-tool browser wait --text "Done"                          # wait until text appears on page
-  oc-tool browser wait "#main" --url "**/dash" --load networkidle  # wait for navigation
-  oc-tool browser highlight e12                               # highlight element (debug)
-  oc-tool browser scrollintoview e12                          # scroll element into view
-Browser rules:
-- Always run snapshot first to get refs (e.g. e6, e12) before clicking/typing
-- Refs come from snapshot output — never guess them
-- Use --interactive flag on snapshot to show only clickable elements
+Discover usage on demand instead of guessing:
+  oc-tool --help                       # list every subcommand
+  oc-tool <subcommand> --help          # full syntax + examples
 
-### Cron (Scheduled Tasks)
-  oc-tool cron status                                # cron system status
-  oc-tool cron list                                  # list all jobs
-  oc-tool cron add '{"name":"job-name","schedule":{"kind":"cron","expression":"0 8 * * *","tz":"Asia/Taipei"},"payload":{"kind":"agentTurn","message":"your prompt"},"deliver":"announce","channel":"telegram"}'
-  oc-tool cron add '{"name":"once","schedule":{"kind":"at","at":"2026-02-17T09:00:00+08:00"},"payload":{"kind":"agentTurn","message":"..."},"deliver":"announce"}'
-  oc-tool cron add '{"name":"every-30m","schedule":{"kind":"every","intervalMs":1800000},"payload":{"kind":"agentTurn","message":"..."}}'
-  oc-tool cron update '{"name":"job-name","schedule":{...}}'  # patch existing job
-  oc-tool cron remove '{"name":"job-name"}'
-  oc-tool cron run '{"name":"job-name"}'             # trigger immediately
-  oc-tool cron runs '{"name":"job-name"}'            # list past run history
-Schedule kinds: "cron" (5-field + timezone), "at" (one-shot ISO timestamp), "every" (intervalMs)
-Payload kinds: "agentTurn" (isolated run with message), "systemEvent" (heartbeat event)
-Deliver: "announce" (send result to chat), "none" (internal only)
+Common subcommand entry points:
+  oc-tool browser    — navigate, snapshot, screenshot, click, type, etc.
+  oc-tool message    — send/read/edit/react/pin across channels
+  oc-tool cron       — list/add/update/remove/run scheduled jobs
+  oc-tool sessions_* — list/history/status of conversation sessions
+  oc-tool tts speak  — generate voice audio (returns MEDIA: path)
+  oc-tool web_search / oc-tool web_fetch
+  oc-tool image      — describe/analyze a local image file
 
-### Message (Send to Channels)
-Cross-channel messaging — send messages to ANY connected channel (Telegram, Slack, Discord, etc.)
-
-#### Telegram
-  oc-tool message send '{"channel":"telegram","target":"telegram:<USER_ID>","message":"..."}'
-  oc-tool message send '{"channel":"telegram","target":"telegram:<USER_ID>","message":"...","replyToId":"<MSG_ID>"}'
-  oc-tool message read '{"channel":"telegram","target":"telegram:<CHAT_ID>","limit":10}'
-  oc-tool message edit '{"channel":"telegram","target":"telegram:<CHAT_ID>","messageId":"<ID>","message":"new text"}'
-  oc-tool message react '{"channel":"telegram","target":"telegram:<CHAT_ID>","messageId":"<ID>","emoji":"👍"}'
-  oc-tool message pin '{"channel":"telegram","target":"telegram:<CHAT_ID>","messageId":"<ID>"}'
-
-#### Slack
-  oc-tool message send '{"channel":"slack","target":"<USER_ID>","message":"..."}'        # DM by Slack user ID (e.g. U0271DRQN3Z)
-  oc-tool message send '{"channel":"slack","target":"channel:<CHANNEL_ID>","message":"..."}'  # send to channel
-  oc-tool message send '{"channel":"slack","target":"channel:<CHANNEL_ID>","message":"...","replyToId":"<MSG_TS>"}'  # thread reply
-  oc-tool message read '{"channel":"slack","target":"channel:<CHANNEL_ID>","limit":10}'
-  oc-tool message edit '{"channel":"slack","target":"channel:<CHANNEL_ID>","messageId":"<MSG_TS>","message":"new text"}'
-  oc-tool message react '{"channel":"slack","target":"channel:<CHANNEL_ID>","messageId":"<MSG_TS>","emoji":"thumbsup"}'
-  oc-tool message pin '{"channel":"slack","target":"channel:<CHANNEL_ID>","messageId":"<MSG_TS>"}'
-Slack notes:
-- target for read/edit/react/pin MUST be "channel:<channelId>" (e.g. "channel:D0AFMGWT3AM") — "#channel-name" does NOT work
-- Slack message IDs are timestamps like "1772450629.016149" (ts field from read output)
-- Slack emoji names are text slugs without colons: "thumbsup", "white_check_mark", etc. (NOT emoji characters)
-- Use send to user ID to get the channelId back, then use that channelId for subsequent read/react/edit/pin
-
-#### Discord
-  oc-tool message send '{"channel":"discord","target":"channel:<CHANNEL_ID>","message":"..."}'
-  oc-tool message send '{"channel":"discord","target":"user:<USER_ID>","message":"..."}'   # DM
-  oc-tool message send '{"channel":"discord","target":"channel:<CHANNEL_ID>","message":"...","replyToId":"<MSG_ID>"}'
-  oc-tool message read '{"channel":"discord","target":"channel:<CHANNEL_ID>","limit":10}'
-  oc-tool message edit '{"channel":"discord","target":"channel:<CHANNEL_ID>","messageId":"<MSG_ID>","message":"new text"}'
-  oc-tool message react '{"channel":"discord","target":"channel:<CHANNEL_ID>","messageId":"<MSG_ID>","emoji":"👍"}'
-  oc-tool message pin '{"channel":"discord","target":"channel:<CHANNEL_ID>","messageId":"<MSG_ID>"}'
-Discord target formats: "channel:<id>" for channels/threads, "user:<id>" for DMs
-
-Cross-channel example (send from current channel to another):
-  oc-tool message send '{"channel":"slack","target":"<USER_ID>","message":"Hello from Discord!"}'
-
-### Sessions
-  oc-tool sessions_list                              # list active sessions
-  oc-tool sessions_history '{"sessionKey":"...","limit":N}'  # get conversation history
-  oc-tool session_status '{"sessionKey":"..."}'      # check session state
-
-### TTS (Text-to-Speech)
-  oc-tool tts speak '{"text":"..."}'                 # generate voice audio (returns MEDIA: path)
-
-### Web
-  oc-tool web_search '{"query":"..."}'               # search the web
-  oc-tool web_fetch '{"url":"..."}'                  # fetch web page content
-
-### Image Analysis
-  oc-tool image '{"url":"file:///path/to/image.png","prompt":"describe this image"}'
+Browser tip: always run \`oc-tool browser snapshot --interactive\` first to get
+element refs (like e6, e12) before clicking/typing — never guess them.
 
 ## Sending Files and Media (CRITICAL)
 To send ANY file (PDF, image, audio, etc.) to the user, you MUST include a MEDIA: line in your response.

--- a/src/server/daemon.ts
+++ b/src/server/daemon.ts
@@ -1,0 +1,174 @@
+/**
+ * Background daemon utilities for the standalone server.
+ *
+ * The proxy is a long-lived process that ought to keep running across
+ * terminal sessions, but it does not need a system-level service manager
+ * (systemd / launchd) for the common case. This module gives `claude-max-api`
+ * a built-in `start` / `stop` / `status` lifecycle by re-spawning itself
+ * as a detached child and tracking it with a small pidfile.
+ *
+ * State files live under ~/.claude-max-api/:
+ *   proxy.pid   — JSON: { pid, port, startedAt }
+ *   proxy.log   — combined stdout+stderr from the background process
+ */
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import { spawn } from "node:child_process";
+
+const STATE_DIR = path.join(os.homedir(), ".claude-max-api");
+export const PID_FILE = path.join(STATE_DIR, "proxy.pid");
+export const LOG_FILE = path.join(STATE_DIR, "proxy.log");
+
+export interface DaemonInfo {
+    pid: number;
+    port: number;
+    startedAt: string;
+}
+
+function ensureStateDir(): void {
+    fs.mkdirSync(STATE_DIR, { recursive: true });
+}
+
+export function readPidFile(): DaemonInfo | null {
+    try {
+        const raw = fs.readFileSync(PID_FILE, "utf8");
+        const parsed = JSON.parse(raw);
+        if (
+            typeof parsed?.pid === "number" &&
+            typeof parsed?.port === "number" &&
+            typeof parsed?.startedAt === "string"
+        ) {
+            return parsed as DaemonInfo;
+        }
+        return null;
+    } catch {
+        return null;
+    }
+}
+
+export function writePidFile(info: DaemonInfo): void {
+    ensureStateDir();
+    fs.writeFileSync(PID_FILE, JSON.stringify(info, null, 2));
+}
+
+export function removePidFile(): void {
+    try {
+        fs.unlinkSync(PID_FILE);
+    } catch {
+        /* ignore — file may have already been removed */
+    }
+}
+
+/**
+ * Best-effort liveness check. process.kill(pid, 0) does not deliver a signal,
+ * it just performs the permission/existence check the kernel does normally.
+ */
+export function isAlive(pid: number): boolean {
+    try {
+        process.kill(pid, 0);
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+/**
+ * Return the live daemon described by the pidfile, or null if there is no
+ * daemon (or the pidfile is stale, in which case we also clean it up).
+ */
+export function getRunningDaemon(): DaemonInfo | null {
+    const info = readPidFile();
+    if (!info) return null;
+    if (!isAlive(info.pid)) {
+        removePidFile();
+        return null;
+    }
+    return info;
+}
+
+/**
+ * Re-spawn the standalone entry point as a detached background process.
+ *
+ * The current Node binary and the script path of the running CLI are reused
+ * verbatim so that whichever way the user invoked us (npm link, global
+ * install, npx, …) keeps working without us having to guess.
+ *
+ * The child is started with `--foreground` so it knows NOT to recurse and
+ * to write its own pidfile after the HTTP listener is up. stdout and stderr
+ * are redirected to LOG_FILE in append mode.
+ */
+export function daemonize(scriptPath: string, args: string[]): number {
+    ensureStateDir();
+    const logFd = fs.openSync(LOG_FILE, "a");
+    try {
+        const child = spawn(process.execPath, [scriptPath, "--foreground", ...args], {
+            detached: true,
+            stdio: ["ignore", logFd, logFd],
+            env: process.env,
+        });
+        child.unref();
+        return child.pid ?? -1;
+    } finally {
+        fs.closeSync(logFd);
+    }
+}
+
+/**
+ * Wait for the background child to register itself in the pidfile.
+ * Resolves with the daemon info, or rejects after `timeoutMs` if the
+ * child failed to come up (the user should then read LOG_FILE).
+ */
+export async function waitForPidFile(timeoutMs = 8_000): Promise<DaemonInfo> {
+    const start = Date.now();
+    while (Date.now() - start < timeoutMs) {
+        const info = readPidFile();
+        if (info && isAlive(info.pid)) return info;
+        await new Promise((r) => setTimeout(r, 100));
+    }
+    throw new Error(
+        `Background process did not register within ${timeoutMs}ms. Check ${LOG_FILE} for startup errors.`,
+    );
+}
+
+/**
+ * SIGTERM the running daemon and wait for it to exit, escalating to SIGKILL
+ * if it does not stop within `timeoutMs`. Cleans up the pidfile in either
+ * case.
+ *
+ * Returns:
+ *   { stopped: true,  pid }  — daemon was running and is now stopped
+ *   { stopped: false, pid: null } — no daemon was running
+ */
+export async function stopDaemon(
+    timeoutMs = 10_000,
+): Promise<{ stopped: boolean; pid: number | null }> {
+    const info = getRunningDaemon();
+    if (!info) return { stopped: false, pid: null };
+
+    try {
+        process.kill(info.pid, "SIGTERM");
+    } catch {
+        // Process is already gone — clean up and report success.
+        removePidFile();
+        return { stopped: true, pid: info.pid };
+    }
+
+    const start = Date.now();
+    while (Date.now() - start < timeoutMs) {
+        if (!isAlive(info.pid)) {
+            removePidFile();
+            return { stopped: true, pid: info.pid };
+        }
+        await new Promise((r) => setTimeout(r, 100));
+    }
+
+    // Did not exit within timeout — escalate.
+    try {
+        process.kill(info.pid, "SIGKILL");
+    } catch {
+        /* ignore */
+    }
+    removePidFile();
+    return { stopped: true, pid: info.pid };
+}

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -31,9 +31,21 @@ function createApp(): express.Express {
         next();
     });
 
-    // CORS headers for local development
-    app.use((_req, res, next) => {
-        res.setHeader("Access-Control-Allow-Origin", "*");
+    // CORS headers. The proxy listens on 127.0.0.1 by default, so the only
+    // legitimate browser callers are pages served from localhost. We mirror
+    // an Origin header back if it looks local; cross-origin requests get no
+    // ACAO header at all (browser will block them). Set CLAUDE_PROXY_ALLOW_CORS_ANY=1
+    // for the legacy "*" behavior if a deployment depends on it.
+    const allowAnyOrigin = process.env.CLAUDE_PROXY_ALLOW_CORS_ANY === "1";
+    const LOCAL_ORIGIN_RE = /^https?:\/\/(?:localhost|127\.0\.0\.1|\[::1\])(?::\d+)?$/;
+    app.use((req, res, next) => {
+        const origin = req.headers.origin;
+        if (allowAnyOrigin) {
+            res.setHeader("Access-Control-Allow-Origin", "*");
+        } else if (typeof origin === "string" && LOCAL_ORIGIN_RE.test(origin)) {
+            res.setHeader("Access-Control-Allow-Origin", origin);
+            res.setHeader("Vary", "Origin");
+        }
         res.setHeader("Access-Control-Allow-Methods", "GET, POST, OPTIONS");
         res.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization");
         next();

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -5,7 +5,7 @@
  */
 import express from "express";
 import { createServer, Server } from "http";
-import { handleChatCompletions, handleModels, handleHealth } from "./routes.js";
+import { handleChatCompletions, handleModels, handleHealth, handleRequests } from "./routes.js";
 
 let serverInstance: Server | null = null;
 
@@ -59,6 +59,7 @@ function createApp(): express.Express {
     // Routes
     app.get("/health", handleHealth);
     app.get("/v1/models", handleModels);
+    app.get("/v1/requests", handleRequests);
     app.post("/v1/chat/completions", handleChatCompletions);
 
     // 404 handler

--- a/src/server/install-service.ts
+++ b/src/server/install-service.ts
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+/**
+ * Post-install hook + manual `install-service` entry point.
+ *
+ * Invocation patterns:
+ *   node install-service.js --auto   # quiet postinstall from package.json
+ *   node install-service.js          # interactive-style manual install
+ *   node install-service.js <port>   # manual install on a specific port
+ *
+ * In --auto mode we bail out silently on any non-fatal condition (local
+ * install, running as root, unsupported platform) so a failed postinstall
+ * never blocks `npm install`. In manual mode we surface the real error.
+ */
+import { detectPlatform, installService, isInstalled } from "./service.js";
+
+const DEFAULT_PORT = 3456;
+
+function parsePort(arg: string | undefined): number {
+    if (!arg) return DEFAULT_PORT;
+    const n = parseInt(arg, 10);
+    if (!Number.isFinite(n) || n < 1 || n > 65535) {
+        throw new Error(`Invalid port: ${arg}`);
+    }
+    return n;
+}
+
+function main(): void {
+    const auto = process.argv.includes("--auto");
+    const positional = process.argv.slice(2).filter((a) => !a.startsWith("--"));
+    const port = parsePort(positional[0]);
+
+    // Skip postinstall for local installs. Only register the service when
+    // the user has actually done `npm install -g`. Otherwise every
+    // `npm install` in the checkout (including CI) would mess with their
+    // login services.
+    if (auto && process.env.npm_config_global !== "true") {
+        return;
+    }
+
+    // Refuse to install as root. `sudo npm install -g` is common on Linux,
+    // but a user-level service installed by root would live under /root and
+    // never auto-start for the actual user. Skip silently in --auto mode so
+    // we don't explode the install, and print a friendly note.
+    if ((process.getuid?.() ?? 0) === 0) {
+        if (!auto) {
+            console.error(
+                "Refusing to install service as root. Re-run without sudo:\n" +
+                    "  claude-max-api install-service",
+            );
+            process.exit(1);
+        }
+        const sudoUser = process.env.SUDO_USER;
+        console.error(
+            `[claude-max-api] Skipping auto service install (running as root${
+                sudoUser ? `, invoked by ${sudoUser}` : ""
+            }).`,
+        );
+        console.error(
+            "[claude-max-api] To enable auto-start on login, run as your normal user:",
+        );
+        console.error("  claude-max-api install-service");
+        return;
+    }
+
+    const platform = detectPlatform();
+    if (!platform) {
+        if (auto) return;
+        console.error(
+            `No supported service backend on ${process.platform}. Use 'claude-max-api start' for the built-in daemon fallback.`,
+        );
+        process.exit(1);
+    }
+
+    try {
+        const wasInstalled = isInstalled();
+        installService(port);
+        if (auto) {
+            console.log(
+                `[claude-max-api] Service ${wasInstalled ? "updated" : "installed"} (${platform}) and set to auto-start on login.`,
+            );
+            console.log(
+                `[claude-max-api] Manage with: claude-max-api {status,stop,restart,logs,uninstall-service}`,
+            );
+        } else {
+            console.log(
+                `Service ${wasInstalled ? "updated" : "installed"} on ${platform}, listening on port ${port}.`,
+            );
+            console.log("It will start automatically on login.");
+        }
+    } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        if (auto) {
+            // Never fail the install. The user can re-run install-service
+            // manually once they've fixed whatever went wrong.
+            console.error(`[claude-max-api] Auto service install skipped: ${message}`);
+            console.error("[claude-max-api] Re-run manually with: claude-max-api install-service");
+            return;
+        }
+        console.error(`Failed to install service: ${message}`);
+        process.exit(1);
+    }
+}
+
+try {
+    main();
+} catch (err) {
+    if (process.argv.includes("--auto")) {
+        // Last-ditch guard: don't ever break npm install on our account.
+        console.error(
+            "[claude-max-api] Post-install hook failed:",
+            err instanceof Error ? err.message : err,
+        );
+        process.exit(0);
+    }
+    throw err;
+}

--- a/src/server/request-tracker.ts
+++ b/src/server/request-tracker.ts
@@ -1,0 +1,104 @@
+/**
+ * In-memory request tracker for the monitor endpoint.
+ *
+ * Keeps a circular buffer of recent request entries so the `mon` CLI
+ * command can poll `/v1/requests` and display live status.
+ */
+
+export type RequestStatus = "in progress" | "completed" | "error";
+
+export interface RequestEntry {
+    id: string;
+    inputLength: number;
+    status: RequestStatus;
+    outputLength: number;
+    startedAt: number;       // Date.now() when the request was received
+    completedAt: number | null;
+}
+
+/** Serialized form returned by the API (adds computed elapsedMs). */
+export interface RequestEntryJSON {
+    id: string;
+    inputLength: number;
+    status: RequestStatus;
+    outputLength: number;
+    startedAt: string;       // ISO 8601
+    elapsedMs: number;
+}
+
+const MAX_ENTRIES = 200;
+
+// Ordered oldest → newest.
+const entries: RequestEntry[] = [];
+
+/**
+ * Register a new in-flight request.
+ */
+export function trackRequest(id: string, inputLength: number): void {
+    if (entries.length >= MAX_ENTRIES) {
+        entries.shift();
+    }
+    entries.push({
+        id,
+        inputLength,
+        status: "in progress",
+        outputLength: 0,
+        startedAt: Date.now(),
+        completedAt: null,
+    });
+}
+
+/**
+ * Update an existing tracked request (e.g. on completion or error).
+ * Silently no-ops if the id is not found (already evicted).
+ */
+export function updateRequest(
+    id: string,
+    patch: Partial<Pick<RequestEntry, "status" | "outputLength">>,
+): void {
+    const entry = entries.find((e) => e.id === id);
+    if (!entry) return;
+    if (patch.status !== undefined) {
+        entry.status = patch.status;
+        if (patch.status === "completed" || patch.status === "error") {
+            entry.completedAt = Date.now();
+        }
+    }
+    if (patch.outputLength !== undefined) {
+        entry.outputLength = patch.outputLength;
+    }
+}
+
+/**
+ * Increment the output length for an in-flight request.
+ */
+export function addOutputBytes(id: string, bytes: number): void {
+    const entry = entries.find((e) => e.id === id);
+    if (entry) entry.outputLength += bytes;
+}
+
+/**
+ * Return the most recent `n` entries (newest first).
+ * Pass -1 or omit to return all.
+ */
+export function getRequests(n?: number): RequestEntryJSON[] {
+    const now = Date.now();
+    // Copy and reverse so newest is first.
+    const reversed = [...entries].reverse();
+    const slice = n != null && n > 0 ? reversed.slice(0, n) : reversed;
+    return slice.map((e) => ({
+        id: e.id,
+        inputLength: e.inputLength,
+        status: e.status,
+        outputLength: e.outputLength,
+        startedAt: new Date(e.startedAt).toISOString(),
+        elapsedMs: (e.completedAt ?? now) - e.startedAt,
+    }));
+}
+
+/**
+ * Return the number of currently in-progress requests.
+ */
+export function getActiveCount(): number {
+    return entries.filter((e) => e.status === "in progress").length;
+}

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -11,6 +11,12 @@ import type { SubprocessOptions } from "../subprocess/manager.js";
 import { openaiToCli, stripAssistantBleed } from "../adapter/openai-to-cli.js";
 import type { CliInput } from "../adapter/openai-to-cli.js";
 import { cliResultToOpenai, createDoneChunk, parseToolCalls, createToolCallChunks } from "../adapter/cli-to-openai.js";
+import type {
+    ClaudeCliAssistant,
+    ClaudeCliMessage,
+    ClaudeCliResult,
+    ClaudeCliStreamEvent,
+} from "../types/claude-cli.js";
 
 
 // ── Auth Error Detection ────────────────────────────────────────────
@@ -345,11 +351,11 @@ async function handleStreamingResponse(
         });
 
         // Log tool calls
-        subprocess.on("message", (msg: any) => {
+        subprocess.on("message", (msg: ClaudeCliMessage) => {
             if (msg.type !== "stream_event") return;
-            const eventType = msg.event?.type;
-            if (eventType === "content_block_start") {
-                const block = msg.event.content_block;
+            const event = msg.event;
+            if (event.type === "content_block_start") {
+                const block = event.content_block;
                 if (block?.type === "tool_use" && block.name) {
                     console.error(`[Stream] Tool call: ${block.name}`);
                 }
@@ -357,7 +363,7 @@ async function handleStreamingResponse(
         });
 
         // Track model name from assistant messages
-        subprocess.on("assistant", (message: any) => {
+        subprocess.on("assistant", (message: ClaudeCliAssistant) => {
             lastModel = message.message.model;
         });
 
@@ -367,12 +373,12 @@ async function handleStreamingResponse(
             // multiple delta chunks. Buffer everything and emit synthesized chunks.
             let toolBuffer = "";
 
-            subprocess.on("content_delta", (event: any) => {
+            subprocess.on("content_delta", (event: ClaudeCliStreamEvent) => {
                 const text = event.event.delta?.text || "";
                 toolBuffer += text;
             });
 
-            subprocess.on("result", (_result: any) => {
+            subprocess.on("result", (_result: ClaudeCliResult) => {
                 isComplete = true;
 
                 // Detect auth errors before forwarding
@@ -418,13 +424,13 @@ async function handleStreamingResponse(
             });
         } else {
             // ── Normal mode: stream deltas through auth-probe + bleed pipeline ─
-            subprocess.on("content_delta", (event: any) => {
+            subprocess.on("content_delta", (event: ClaudeCliStreamEvent) => {
                 const text = event.event.delta?.text || "";
                 if (!text) return;
                 ingestDelta(text);
             });
 
-            subprocess.on("result", (_result: any) => {
+            subprocess.on("result", (_result: ClaudeCliResult) => {
                 isComplete = true;
 
                 // Drain any held-back auth probe before finishing.
@@ -493,7 +499,7 @@ async function handleNonStreamingResponse(
     subOpts: SubprocessOptions
 ): Promise<void> {
     return new Promise<void>((resolve) => {
-        let finalResult: any = null;
+        let finalResult: ClaudeCliResult | null = null;
         // Each call to subprocess events fires from independent emitters,
         // so error/close/start can race. The first one to write the response
         // owns it; everything else must early-return.
@@ -507,7 +513,7 @@ async function handleNonStreamingResponse(
             fn();
         };
 
-        subprocess.on("result", (result) => {
+        subprocess.on("result", (result: ClaudeCliResult) => {
             finalResult = result;
         });
 

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -125,12 +125,11 @@ async function handleStreamingResponse(
         let allContent = ""; // Track all content for auth error detection
 
         // ── Bleed detection state ──────────────────────────────────
-        // We accumulate streamed text to detect [User]/[Human] bleed patterns.
-        // Once a bleed sentinel is detected, we stop forwarding further deltas.
-        let accumulated = "";
-        let totalFlushed = 0;
+        // We hold back a small tail buffer (MAX_SENTINEL_LEN bytes) so a
+        // bleed sentinel that straddles two delta chunks is still caught,
+        // without rescanning the entire response on every delta.
+        let tail = "";
         let bleedDetected = false;
-        // Longest sentinel we watch for, so we know how much tail to hold back
         const BLEED_SENTINELS = ["\n[User]", "\n[Human]", "\nHuman:"];
         const MAX_SENTINEL_LEN = Math.max(...BLEED_SENTINELS.map((s) => s.length));
 
@@ -159,33 +158,43 @@ async function handleStreamingResponse(
 
         /**
          * Process an incoming delta with bleed detection.
-         * We keep a tail buffer (MAX_SENTINEL_LEN chars) unwritten until we're
-         * sure it doesn't start a bleed pattern — this prevents partial sentinels
-         * (split across two deltas) from leaking through.
+         * Keeps a tail buffer (MAX_SENTINEL_LEN chars) unwritten until the
+         * next delta arrives so a sentinel split across two deltas is still
+         * caught, while running in O(incoming.length + MAX_SENTINEL_LEN) per
+         * call instead of rescanning the full accumulated response each time.
          */
         function processDelta(incoming: string): void {
-            if (bleedDetected || res.writableEnded) return;
+            if (bleedDetected || res.writableEnded || !incoming) return;
 
-            accumulated += incoming;
+            const buf = tail + incoming;
 
-            // Check if the accumulated text contains a bleed sentinel
-            const safe = stripAssistantBleed(accumulated);
-            if (safe.length < accumulated.length) {
-                // Bleed found — write only the unflushed safe portion and stop
+            // Search only the (small) tail+incoming window for sentinels.
+            // The earlier flushed prefix has already been cleared by previous
+            // calls, so any sentinel must lie within this window.
+            let cutAt = -1;
+            for (const sentinel of BLEED_SENTINELS) {
+                const idx = buf.indexOf(sentinel);
+                if (idx !== -1 && (cutAt === -1 || idx < cutAt)) {
+                    cutAt = idx;
+                }
+            }
+
+            if (cutAt !== -1) {
                 bleedDetected = true;
-                const safeNew = safe.slice(totalFlushed);
-                if (safeNew) writeDelta(safeNew);
+                const safe = buf.slice(0, cutAt);
+                if (safe) writeDelta(safe);
+                tail = "";
                 console.error("[Stream] Bleed detected — halting delta stream");
                 return;
             }
 
-            // No bleed yet, but hold back the last MAX_SENTINEL_LEN chars as a
-            // look-ahead buffer in case a sentinel straddles two delta chunks.
-            const safeLen = Math.max(0, accumulated.length - MAX_SENTINEL_LEN);
-            const toFlush = safeLen - totalFlushed;
-            if (toFlush > 0) {
-                writeDelta(accumulated.slice(totalFlushed, totalFlushed + toFlush));
-                totalFlushed += toFlush;
+            // Hold back the last MAX_SENTINEL_LEN chars as a look-ahead buffer.
+            if (buf.length > MAX_SENTINEL_LEN) {
+                const flushUntil = buf.length - MAX_SENTINEL_LEN;
+                writeDelta(buf.slice(0, flushUntil));
+                tail = buf.slice(flushUntil);
+            } else {
+                tail = buf;
             }
         }
 
@@ -194,10 +203,10 @@ async function handleStreamingResponse(
          * Run through stripAssistantBleed one more time for safety.
          */
         function flushTail(): void {
-            if (bleedDetected || res.writableEnded) return;
-            const safe = stripAssistantBleed(accumulated);
-            const remaining = safe.slice(totalFlushed);
-            if (remaining) writeDelta(remaining);
+            if (bleedDetected || res.writableEnded || !tail) return;
+            const safe = stripAssistantBleed(tail);
+            if (safe) writeDelta(safe);
+            tail = "";
         }
         // ──────────────────────────────────────────────────────────
 

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -260,14 +260,13 @@ async function handleStreamingResponse(
 
                 if (!res.writableEnded) {
                     if (hasToolCalls) {
-                        // Emit synthesized tool call SSE chunks
+                        // Emit synthesized tool call SSE chunks. The chunks
+                        // already include a finish_reason:"tool_calls" terminator,
+                        // so we only need a single [DONE] sentinel after them.
                         const chunks = createToolCallChunks(toolCalls, requestId, lastModel);
                         for (const chunk of chunks) {
                             res.write(`data: ${JSON.stringify(chunk)}\n\n`);
                         }
-                        // Use [DONE] as the sole end signal for tool call responses
-                        // (tool call chunks already have finish_reason:"tool_calls")
-                        res.write("data: [DONE]\n\n");
                     } else {
                         // No tool calls — emit full text as a single content chunk
                         if (textWithoutToolCalls) {

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -95,8 +95,13 @@ export async function handleChatCompletions(req: Request, res: Response): Promis
             body.tools.length > 0 &&
             body.tool_choice !== "none";
 
+        // The client-supplied model string is what we echo back in chunks,
+        // not the CLI-mapped value (which may collapse to "opus"/"sonnet").
+        const clientModel: string =
+            typeof body.model === "string" && body.model ? body.model : "claude-sonnet-4";
+
         if (stream) {
-            await handleStreamingResponse(res, subprocess, cliInput, requestId, subOpts, hasTools);
+            await handleStreamingResponse(res, subprocess, cliInput, requestId, subOpts, clientModel, hasTools);
         } else {
             await handleNonStreamingResponse(res, subprocess, cliInput, requestId, subOpts);
         }
@@ -141,6 +146,7 @@ async function handleStreamingResponse(
     cliInput: CliInput,
     requestId: string,
     subOpts: SubprocessOptions,
+    clientModel: string,
     hasTools = false
 ): Promise<void> {
     // Set SSE headers
@@ -162,13 +168,16 @@ async function handleStreamingResponse(
         id: `chatcmpl-${requestId}`,
         object: "chat.completion.chunk",
         created: Math.floor(Date.now() / 1000),
-        model: "claude-sonnet-4",
+        model: clientModel,
         choices: [{ index: 0, delta: { role: "assistant" }, finish_reason: null }],
     };
     res.write(`data: ${JSON.stringify(announceChunk)}\n\n`);
 
     return new Promise<void>((resolve, reject) => {
-        let lastModel = "claude-sonnet-4";
+        // Default to the client-requested model so the very first content
+        // chunks aren't tagged with the wrong family. The CLI will overwrite
+        // this with the real model id once the assistant message arrives.
+        let lastModel = clientModel;
         let isComplete = false;
 
         // ── Bleed detection state ──────────────────────────────────

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -133,6 +133,15 @@ async function handleStreamingResponse(
         const BLEED_SENTINELS = ["\n[User]", "\n[Human]", "\nHuman:"];
         const MAX_SENTINEL_LEN = Math.max(...BLEED_SENTINELS.map((s) => s.length));
 
+        // ── Auth-error probe state ─────────────────────────────────
+        // Hold back the first AUTH_PROBE_BYTES of streamed text so we can
+        // detect "not logged in" before any of it is forwarded to the client.
+        // Once the buffer is large enough — or the stream ends — we either
+        // emit an auth error or flush the buffer through the normal pipeline.
+        const AUTH_PROBE_BYTES = 1024;
+        let authProbe = "";
+        let authProbeCleared = false;
+
         /**
          * Write a delta chunk to the SSE stream.
          */
@@ -207,6 +216,71 @@ async function handleStreamingResponse(
             const safe = stripAssistantBleed(tail);
             if (safe) writeDelta(safe);
             tail = "";
+        }
+
+        /**
+         * Emit a structured auth error and tear down the stream.
+         * Used by both the early probe (in delta handler) and the late
+         * fallback (in result handler) so the wire format stays identical.
+         */
+        function emitAuthError(): void {
+            console.error("[Stream] Auth error detected — aborting stream");
+            if (!res.writableEnded) {
+                res.write(`data: ${JSON.stringify({
+                    error: { message: "Claude CLI is not authenticated. Run: claude login", type: "auth_error", code: "not_authenticated" },
+                })}\n\n`);
+                res.write("data: [DONE]\n\n");
+                res.end();
+            }
+            isComplete = true;
+            subprocess.kill();
+            resolve();
+        }
+
+        /**
+         * Buffer the first AUTH_PROBE_BYTES of streamed text and only forward
+         * it once we are confident it is not an auth error. This prevents
+         * "not logged in" content from leaking to the client before we can
+         * replace it with a structured auth_error.
+         *
+         * Returns true if the stream should keep running, false if we have
+         * already terminated it (auth error confirmed).
+         */
+        function ingestDelta(text: string): boolean {
+            if (authProbeCleared) {
+                processDelta(text);
+                return true;
+            }
+            authProbe += text;
+            if (isAuthError(authProbe)) {
+                emitAuthError();
+                return false;
+            }
+            if (authProbe.length >= AUTH_PROBE_BYTES) {
+                authProbeCleared = true;
+                const drained = authProbe;
+                authProbe = "";
+                processDelta(drained);
+            }
+            return true;
+        }
+
+        /**
+         * Drain the auth probe buffer at end-of-stream. Returns false if an
+         * auth error was detected (caller should bail out without writing
+         * the normal completion chunks).
+         */
+        function drainAuthProbe(): boolean {
+            if (authProbeCleared || !authProbe) return true;
+            if (isAuthError(authProbe)) {
+                emitAuthError();
+                return false;
+            }
+            authProbeCleared = true;
+            const drained = authProbe;
+            authProbe = "";
+            processDelta(drained);
+            return true;
         }
         // ──────────────────────────────────────────────────────────
 
@@ -290,30 +364,21 @@ async function handleStreamingResponse(
                 resolve();
             });
         } else {
-            // ── Normal mode: stream deltas through bleed detection ────────────
+            // ── Normal mode: stream deltas through auth-probe + bleed pipeline ─
             subprocess.on("content_delta", (event: any) => {
                 const text = event.event.delta?.text || "";
                 if (!text) return;
                 allContent += text;
-                processDelta(text);
+                ingestDelta(text);
             });
 
             subprocess.on("result", (_result: any) => {
                 isComplete = true;
 
-                // Detect auth errors before forwarding
-                if (isAuthError(allContent)) {
-                    console.error("[Stream] Auth error detected in CLI output");
-                    if (!res.writableEnded) {
-                        res.write(`data: ${JSON.stringify({
-                            error: { message: "Claude CLI is not authenticated. Run: claude login", type: "auth_error", code: "not_authenticated" },
-                        })}\n\n`);
-                        res.write("data: [DONE]\n\n");
-                        res.end();
-                    }
-                    resolve();
-                    return;
-                }
+                // Drain any held-back auth probe before finishing.
+                // drainAuthProbe() returns false if it terminated the stream
+                // with an auth error — in which case we have nothing more to do.
+                if (!drainAuthProbe()) return;
 
                 // Flush any buffered tail through bleed detection before finishing
                 flushTail();

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -11,6 +11,7 @@ import type { SubprocessOptions } from "../subprocess/manager.js";
 import { openaiToCli, stripAssistantBleed } from "../adapter/openai-to-cli.js";
 import type { CliInput } from "../adapter/openai-to-cli.js";
 import { cliResultToOpenai, createDoneChunk, parseToolCalls, createToolCallChunks } from "../adapter/cli-to-openai.js";
+import { trackRequest, updateRequest, addOutputBytes, getRequests, getActiveCount } from "./request-tracker.js";
 import type {
     ClaudeCliAssistant,
     ClaudeCliMessage,
@@ -72,6 +73,8 @@ export async function handleChatCompletions(req: Request, res: Response): Promis
     }
 
     activeRequests += 1;
+    const inputLength = Buffer.byteLength(JSON.stringify(body.messages), "utf8");
+    trackRequest(requestId, inputLength);
     try {
         // Validate request
         if (!body.messages || !Array.isArray(body.messages) || body.messages.length === 0) {
@@ -112,6 +115,7 @@ export async function handleChatCompletions(req: Request, res: Response): Promis
             await handleNonStreamingResponse(res, subprocess, cliInput, requestId, subOpts);
         }
     } catch (error) {
+        updateRequest(requestId, { status: "error" });
         const message = error instanceof Error ? error.message : "Unknown error";
         const stack = error instanceof Error ? error.stack : "";
         console.error("[handleChatCompletions] Error:", message);
@@ -376,14 +380,17 @@ async function handleStreamingResponse(
             subprocess.on("content_delta", (event: ClaudeCliStreamEvent) => {
                 const text = event.event.delta?.text || "";
                 toolBuffer += text;
+                addOutputBytes(requestId, Buffer.byteLength(text, "utf8"));
             });
 
             subprocess.on("result", (_result: ClaudeCliResult) => {
                 isComplete = true;
+                updateRequest(requestId, { status: "completed" });
 
                 // Detect auth errors before forwarding
                 if (isAuthError(toolBuffer)) {
                     console.error("[Stream] Auth error detected in CLI output");
+                    updateRequest(requestId, { status: "error" });
                     if (!res.writableEnded) {
                         res.write(`data: ${JSON.stringify({
                             error: { message: "Claude CLI is not authenticated. Run: claude login", type: "auth_error", code: "not_authenticated" },
@@ -427,16 +434,21 @@ async function handleStreamingResponse(
             subprocess.on("content_delta", (event: ClaudeCliStreamEvent) => {
                 const text = event.event.delta?.text || "";
                 if (!text) return;
+                addOutputBytes(requestId, Buffer.byteLength(text, "utf8"));
                 ingestDelta(text);
             });
 
             subprocess.on("result", (_result: ClaudeCliResult) => {
                 isComplete = true;
+                updateRequest(requestId, { status: "completed" });
 
                 // Drain any held-back auth probe before finishing.
                 // drainAuthProbe() returns false if it terminated the stream
                 // with an auth error — in which case we have nothing more to do.
-                if (!drainAuthProbe()) return;
+                if (!drainAuthProbe()) {
+                    updateRequest(requestId, { status: "error" });
+                    return;
+                }
 
                 // Flush any buffered tail through bleed detection before finishing
                 flushTail();
@@ -451,6 +463,7 @@ async function handleStreamingResponse(
         }
 
         subprocess.on("error", (error: Error) => {
+            updateRequest(requestId, { status: "error" });
             console.error("[Streaming] Error:", error.message);
             if (!res.writableEnded) {
                 res.write(`data: ${JSON.stringify({
@@ -462,6 +475,9 @@ async function handleStreamingResponse(
         });
 
         subprocess.on("close", (code: number | null) => {
+            if (code !== 0 && !isComplete) {
+                updateRequest(requestId, { status: "error" });
+            }
             // Subprocess exited - ensure response is closed
             if (!res.writableEnded) {
                 if (code !== 0 && !isComplete) {
@@ -518,6 +534,7 @@ async function handleNonStreamingResponse(
         });
 
         subprocess.on("error", (error) => {
+            updateRequest(requestId, { status: "error" });
             console.error("[NonStreaming] Error:", error.message);
             respond(() => {
                 res.status(500).json({
@@ -534,6 +551,7 @@ async function handleNonStreamingResponse(
                     // Detect auth errors
                     if (isAuthError(resultText)) {
                         console.error("[NonStreaming] Auth error detected in CLI output");
+                        updateRequest(requestId, { status: "error" });
                         res.status(503).json({
                             error: { message: "Claude CLI is not authenticated. Run: claude login", type: "auth_error", code: "not_authenticated" },
                         });
@@ -544,8 +562,11 @@ async function handleNonStreamingResponse(
                         ...finalResult,
                         result: stripAssistantBleed(resultText),
                     };
+                    const outputLength = Buffer.byteLength(finalResult.result ?? "", "utf8");
+                    updateRequest(requestId, { status: "completed", outputLength });
                     res.json(cliResultToOpenai(finalResult, requestId));
                 } else {
+                    updateRequest(requestId, { status: "error" });
                     res.status(500).json({
                         error: {
                             message: `Claude CLI exited with code ${code} without response`,
@@ -592,6 +613,21 @@ export function handleHealth(_req: Request, res: Response): void {
     res.json({
         status: "ok",
         provider: "claude-code-cli",
+        timestamp: new Date().toISOString(),
+    });
+}
+
+/**
+ * Handle GET /v1/requests — Returns recent request status for the monitor
+ */
+export function handleRequests(req: Request, res: Response): void {
+    const rawN = req.query.n;
+    const n = typeof rawN === "string" ? parseInt(rawN, 10) : 20;
+    const limit = n === -1 ? undefined : (Number.isFinite(n) && n > 0 ? n : 20);
+    res.json({
+        requests: getRequests(limit),
+        active: getActiveCount(),
+        maxConcurrent: MAX_CONCURRENT,
         timestamp: new Date().toISOString(),
     });
 }

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -76,6 +76,21 @@ export async function handleChatCompletions(req: Request, res: Response): Promis
             res.status(500).json({
                 error: { message, type: "server_error", code: null },
             });
+        } else if (!res.writableEnded) {
+            // Headers were already flushed for SSE (we sent the role-announce
+            // chunk before subprocess.start() ran), so we cannot fall back to
+            // res.status(500).json(). Instead, write a structured error event
+            // followed by [DONE] so streaming clients see a real failure
+            // instead of a silently truncated stream.
+            try {
+                res.write(`data: ${JSON.stringify({
+                    error: { message, type: "server_error", code: null },
+                })}\n\n`);
+                res.write("data: [DONE]\n\n");
+                res.end();
+            } catch (writeErr) {
+                console.error("[handleChatCompletions] Failed to write SSE error fallback:", writeErr);
+            }
         }
     }
 }

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -63,7 +63,7 @@ export async function handleChatCompletions(req: Request, res: Response): Promis
             body.tool_choice !== "none";
 
         if (stream) {
-            await handleStreamingResponse(req, res, subprocess, cliInput, requestId, subOpts, hasTools);
+            await handleStreamingResponse(res, subprocess, cliInput, requestId, subOpts, hasTools);
         } else {
             await handleNonStreamingResponse(res, subprocess, cliInput, requestId, subOpts);
         }
@@ -86,7 +86,6 @@ export async function handleChatCompletions(req: Request, res: Response): Promis
  * Each content_delta event is immediately written to the response stream.
  */
 async function handleStreamingResponse(
-    req: Request,
     res: Response,
     subprocess: ClaudeSubprocess,
     cliInput: CliInput,
@@ -121,8 +120,6 @@ async function handleStreamingResponse(
     return new Promise<void>((resolve, reject) => {
         let lastModel = "claude-sonnet-4";
         let isComplete = false;
-        let isFirst = false; // role:"assistant" already sent in the announce chunk above
-        let allContent = ""; // Track all content for auth error detection
 
         // ── Bleed detection state ──────────────────────────────────
         // We hold back a small tail buffer (MAX_SENTINEL_LEN bytes) so a
@@ -143,7 +140,9 @@ async function handleStreamingResponse(
         let authProbeCleared = false;
 
         /**
-         * Write a delta chunk to the SSE stream.
+         * Write a content delta chunk to the SSE stream.
+         * The role:"assistant" announcement was already sent up-front, so
+         * subsequent deltas only carry the content payload.
          */
         function writeDelta(text: string): void {
             if (!text || res.writableEnded) return;
@@ -154,15 +153,11 @@ async function handleStreamingResponse(
                 model: lastModel,
                 choices: [{
                     index: 0,
-                    delta: {
-                        role: isFirst ? ("assistant" as const) : undefined,
-                        content: text,
-                    },
+                    delta: { content: text },
                     finish_reason: null,
                 }],
             };
             res.write(`data: ${JSON.stringify(chunk)}\n\n`);
-            isFirst = false;
         }
 
         /**
@@ -316,7 +311,6 @@ async function handleStreamingResponse(
             subprocess.on("content_delta", (event: any) => {
                 const text = event.event.delta?.text || "";
                 toolBuffer += text;
-                allContent += text;
             });
 
             subprocess.on("result", (_result: any) => {
@@ -368,7 +362,6 @@ async function handleStreamingResponse(
             subprocess.on("content_delta", (event: any) => {
                 const text = event.event.delta?.text || "";
                 if (!text) return;
-                allContent += text;
                 ingestDelta(text);
             });
 

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -296,7 +296,6 @@ async function handleStreamingResponse(
                 // Detect auth errors before forwarding
                 if (isAuthError(allContent)) {
                     console.error("[Stream] Auth error detected in CLI output");
-                    progress.cleanup().catch(() => {});
                     if (!res.writableEnded) {
                         res.write(`data: ${JSON.stringify({
                             error: { message: "Claude CLI is not authenticated. Run: claude login", type: "auth_error", code: "not_authenticated" },

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -435,6 +435,18 @@ async function handleNonStreamingResponse(
 ): Promise<void> {
     return new Promise<void>((resolve) => {
         let finalResult: any = null;
+        // Each call to subprocess events fires from independent emitters,
+        // so error/close/start can race. The first one to write the response
+        // owns it; everything else must early-return.
+        let responded = false;
+        const respond = (fn: () => void): void => {
+            if (responded || res.headersSent) {
+                responded = true;
+                return;
+            }
+            responded = true;
+            fn();
+        };
 
         subprocess.on("result", (result) => {
             finalResult = result;
@@ -442,46 +454,51 @@ async function handleNonStreamingResponse(
 
         subprocess.on("error", (error) => {
             console.error("[NonStreaming] Error:", error.message);
-            res.status(500).json({
-                error: { message: error.message, type: "server_error", code: null },
+            respond(() => {
+                res.status(500).json({
+                    error: { message: error.message, type: "server_error", code: null },
+                });
             });
             resolve();
         });
 
         subprocess.on("close", (code) => {
-            if (finalResult) {
-                const resultText = finalResult.result ?? "";
-                // Detect auth errors
-                if (isAuthError(resultText)) {
-                    console.error("[NonStreaming] Auth error detected in CLI output");
-                    res.status(503).json({
-                        error: { message: "Claude CLI is not authenticated. Run: claude login", type: "auth_error", code: "not_authenticated" },
+            respond(() => {
+                if (finalResult) {
+                    const resultText = finalResult.result ?? "";
+                    // Detect auth errors
+                    if (isAuthError(resultText)) {
+                        console.error("[NonStreaming] Auth error detected in CLI output");
+                        res.status(503).json({
+                            error: { message: "Claude CLI is not authenticated. Run: claude login", type: "auth_error", code: "not_authenticated" },
+                        });
+                        return;
+                    }
+                    // Strip any [User]/[Human] bleed from the final result text
+                    finalResult = {
+                        ...finalResult,
+                        result: stripAssistantBleed(resultText),
+                    };
+                    res.json(cliResultToOpenai(finalResult, requestId));
+                } else {
+                    res.status(500).json({
+                        error: {
+                            message: `Claude CLI exited with code ${code} without response`,
+                            type: "server_error",
+                            code: null,
+                        },
                     });
-                    resolve();
-                    return;
                 }
-                // Strip any [User]/[Human] bleed from the final result text
-                finalResult = {
-                    ...finalResult,
-                    result: stripAssistantBleed(resultText),
-                };
-                res.json(cliResultToOpenai(finalResult, requestId));
-            } else if (!res.headersSent) {
-                res.status(500).json({
-                    error: {
-                        message: `Claude CLI exited with code ${code} without response`,
-                        type: "server_error",
-                        code: null,
-                    },
-                });
-            }
+            });
             resolve();
         });
 
         // Start the subprocess with session-aware options
         subprocess.start(cliInput.prompt, subOpts).catch((error) => {
-            res.status(500).json({
-                error: { message: error.message, type: "server_error", code: null },
+            respond(() => {
+                res.status(500).json({
+                    error: { message: error.message, type: "server_error", code: null },
+                });
             });
             resolve();
         });

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -21,6 +21,20 @@ function isAuthError(text: string): boolean {
     return AUTH_ERROR_PATTERNS.some((p) => lower.includes(p));
 }
 
+// ── Concurrency Limit ──────────────────────────────────────────────
+// Each in-flight chat request spawns a Claude CLI subprocess, which is
+// expensive (hundreds of MB of RAM each). Cap concurrency to avoid
+// OOM-killing the box on a burst of requests. Excess requests get a
+// 429 with Retry-After so well-behaved clients back off cleanly.
+const DEFAULT_MAX_CONCURRENT = 4;
+const MAX_CONCURRENT = (() => {
+    const raw = process.env.CLAUDE_PROXY_MAX_CONCURRENT;
+    if (!raw) return DEFAULT_MAX_CONCURRENT;
+    const parsed = parseInt(raw, 10);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_MAX_CONCURRENT;
+})();
+let activeRequests = 0;
+
 // ── Route Handlers ─────────────────────────────────────────────────
 
 /**
@@ -33,6 +47,25 @@ export async function handleChatCompletions(req: Request, res: Response): Promis
     const body = req.body;
     const stream = body.stream === true;
 
+    // Reject early if we are already at the configured concurrency cap.
+    // Each handler spawns a separate Claude CLI subprocess (~200+ MB RSS),
+    // so unbounded concurrency will OOM the box on a burst.
+    if (activeRequests >= MAX_CONCURRENT) {
+        console.error(
+            `[handleChatCompletions] Rejecting request — at concurrency limit ${activeRequests}/${MAX_CONCURRENT}`,
+        );
+        res.setHeader("Retry-After", "5");
+        res.status(429).json({
+            error: {
+                message: `Too many concurrent requests (limit ${MAX_CONCURRENT}). Retry shortly.`,
+                type: "rate_limit_error",
+                code: "concurrency_limit",
+            },
+        });
+        return;
+    }
+
+    activeRequests += 1;
     try {
         // Validate request
         if (!body.messages || !Array.isArray(body.messages) || body.messages.length === 0) {
@@ -92,6 +125,8 @@ export async function handleChatCompletions(req: Request, res: Response): Promis
                 console.error("[handleChatCompletions] Failed to write SSE error fallback:", writeErr);
             }
         }
+    } finally {
+        activeRequests -= 1;
     }
 }
 

--- a/src/server/service.ts
+++ b/src/server/service.ts
@@ -1,0 +1,370 @@
+/**
+ * Platform-aware OS service manager.
+ *
+ * Registers the proxy as a user-level service that auto-starts on login and
+ * exposes a cross-platform start/stop/restart/status API. The `standalone`
+ * CLI dispatches to this module so `claude-max-api start` behaves the same
+ * way whether we're on macOS (launchd) or Linux with systemd user units.
+ *
+ *   macOS          ~/Library/LaunchAgents/com.claude-max-api.plist  (launchctl)
+ *   Linux/systemd  ~/.config/systemd/user/claude-max-api.service    (systemctl --user)
+ *   anything else  null platform — callers fall back to the built-in daemonize()
+ *
+ * We intentionally stay in the user domain: no root, no LaunchDaemons, no
+ * system-level systemd units. That matches the security posture of the
+ * foreground binary (the proxy itself should never run as root).
+ */
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+import { LOG_FILE } from "./daemon.js";
+
+export type ServicePlatform = "darwin" | "linux-systemd" | null;
+
+export const SERVICE_LABEL = "com.claude-max-api";
+export const SERVICE_UNIT = "claude-max-api";
+
+// ── Platform detection ────────────────────────────────────────────
+
+/**
+ * Detect which service backend (if any) we can drive on the current host.
+ * Returns null on unsupported platforms so callers can fall back to the
+ * built-in daemonize() path.
+ */
+export function detectPlatform(): ServicePlatform {
+    if (process.platform === "darwin") return "darwin";
+    if (process.platform === "linux") {
+        const r = spawnSync("systemctl", ["--user", "--version"], {
+            stdio: ["ignore", "ignore", "ignore"],
+        });
+        if (r.status === 0) return "linux-systemd";
+    }
+    return null;
+}
+
+// ── Paths ─────────────────────────────────────────────────────────
+
+function plistPath(): string {
+    return path.join(os.homedir(), "Library", "LaunchAgents", `${SERVICE_LABEL}.plist`);
+}
+
+function unitPath(): string {
+    return path.join(os.homedir(), ".config", "systemd", "user", `${SERVICE_UNIT}.service`);
+}
+
+/**
+ * Absolute path to the standalone.js that should be invoked by the service.
+ * Resolves relative to *this* compiled module (dist/server/service.js), so
+ * whichever directory npm/global-install unpacks us into is the one that
+ * gets baked into the service definition.
+ */
+function resolveScriptPath(): string {
+    const here = fileURLToPath(import.meta.url);
+    return path.join(path.dirname(here), "standalone.js");
+}
+
+// ── Plist / unit templates ────────────────────────────────────────
+
+interface UnitOptions {
+    port: number;
+    nodePath: string;
+    scriptPath: string;
+    home: string;
+    path: string;
+}
+
+function plistBody(opts: UnitOptions): string {
+    // KeepAlive.SuccessfulExit=false means launchd only restarts us on
+    // abnormal exits (crash, OOM). A clean shutdown via `claude-max-api stop`
+    // leaves the job unloaded, which is what the user wants.
+    return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key><string>${SERVICE_LABEL}</string>
+    <key>RunAtLoad</key><true/>
+    <key>KeepAlive</key>
+    <dict>
+        <key>SuccessfulExit</key><false/>
+    </dict>
+    <key>ProgramArguments</key>
+    <array>
+        <string>${opts.nodePath}</string>
+        <string>${opts.scriptPath}</string>
+        <string>--foreground</string>
+        <string>${opts.port}</string>
+    </array>
+    <key>StandardOutPath</key><string>${LOG_FILE}</string>
+    <key>StandardErrorPath</key><string>${LOG_FILE}</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key><string>${opts.home}</string>
+        <key>PATH</key><string>${opts.path}</string>
+    </dict>
+</dict>
+</plist>
+`;
+}
+
+function unitBody(opts: UnitOptions): string {
+    // Restart=on-failure mirrors launchd's "restart on crash" posture:
+    // a clean `systemctl --user stop` leaves the service stopped.
+    return `[Unit]
+Description=Claude Max API Proxy
+After=network.target
+
+[Service]
+Type=simple
+Environment=HOME=${opts.home}
+Environment=PATH=${opts.path}
+ExecStart=${opts.nodePath} ${opts.scriptPath} --foreground ${opts.port}
+Restart=on-failure
+RestartSec=5s
+StandardOutput=append:${LOG_FILE}
+StandardError=append:${LOG_FILE}
+
+[Install]
+WantedBy=default.target
+`;
+}
+
+// ── Option resolution ─────────────────────────────────────────────
+
+function buildOptions(port: number): UnitOptions {
+    const home = os.homedir();
+    // Seed PATH with common bin dirs so the service can find `claude`,
+    // `oc-tool`, `ffmpeg`, etc. even when launched outside a login shell.
+    const seeded = [
+        path.join(home, ".npm-global", "bin"),
+        path.join(home, ".nvm", "versions", "node"),
+        path.join(home, ".local", "bin"),
+        "/opt/homebrew/bin",
+        "/usr/local/bin",
+        "/usr/bin",
+        "/bin",
+    ];
+    const inherited = (process.env.PATH ?? "").split(":").filter(Boolean);
+    const merged = Array.from(new Set([...inherited, ...seeded])).join(":");
+    return {
+        port,
+        nodePath: process.execPath,
+        scriptPath: resolveScriptPath(),
+        home,
+        path: merged,
+    };
+}
+
+// ── Helpers ───────────────────────────────────────────────────────
+
+function run(
+    cmd: string,
+    args: string[],
+): { ok: boolean; stdout: string; stderr: string; status: number | null } {
+    const r = spawnSync(cmd, args, { stdio: ["ignore", "pipe", "pipe"], encoding: "utf8" });
+    return {
+        ok: r.status === 0,
+        stdout: (r.stdout ?? "").toString(),
+        stderr: (r.stderr ?? "").toString(),
+        status: r.status,
+    };
+}
+
+function uid(): number {
+    return process.getuid?.() ?? 0;
+}
+
+function ensureDir(p: string): void {
+    fs.mkdirSync(path.dirname(p), { recursive: true });
+}
+
+// ── Public API ────────────────────────────────────────────────────
+
+export interface ServiceStatus {
+    installed: boolean;
+    running: boolean;
+    /** Free-form human-readable detail line. */
+    detail: string;
+}
+
+export function isInstalled(): boolean {
+    const platform = detectPlatform();
+    if (platform === "darwin") return fs.existsSync(plistPath());
+    if (platform === "linux-systemd") return fs.existsSync(unitPath());
+    return false;
+}
+
+export function serviceStatus(): ServiceStatus {
+    const platform = detectPlatform();
+    if (!platform) return { installed: false, running: false, detail: "platform unsupported" };
+
+    if (platform === "darwin") {
+        if (!fs.existsSync(plistPath())) {
+            return { installed: false, running: false, detail: "not installed" };
+        }
+        const r = run("launchctl", ["print", `gui/${uid()}/${SERVICE_LABEL}`]);
+        if (!r.ok) return { installed: true, running: false, detail: "loaded=no" };
+        // `state = running` appears in the print output when the process is alive.
+        const running = /state\s*=\s*running/.test(r.stdout);
+        return {
+            installed: true,
+            running,
+            detail: running ? "state=running" : "state=not running",
+        };
+    }
+
+    // linux-systemd
+    if (!fs.existsSync(unitPath())) {
+        return { installed: false, running: false, detail: "not installed" };
+    }
+    const r = run("systemctl", ["--user", "is-active", SERVICE_UNIT]);
+    const state = r.stdout.trim() || r.stderr.trim() || "unknown";
+    return { installed: true, running: state === "active", detail: `state=${state}` };
+}
+
+/**
+ * Write the service unit and register it with the platform's init system.
+ * Idempotent: if already installed, the unit is overwritten and the service
+ * restarted so upgrades pick up the new `node`/script paths.
+ */
+export function installService(port: number): void {
+    const platform = detectPlatform();
+    if (!platform) {
+        throw new Error(
+            `Unsupported platform: ${process.platform}. Use 'claude-max-api' directly or the built-in 'start' fallback.`,
+        );
+    }
+    if (uid() === 0) {
+        throw new Error(
+            "Refusing to install service as root — run without sudo so the unit lives under your own user.",
+        );
+    }
+
+    const opts = buildOptions(port);
+    fs.mkdirSync(path.dirname(LOG_FILE), { recursive: true });
+
+    if (platform === "darwin") {
+        const target = plistPath();
+        ensureDir(target);
+        // If the unit is already loaded, bootout first so the new plist takes
+        // effect on next bootstrap. Ignore failures — service may be absent.
+        run("launchctl", ["bootout", `gui/${uid()}/${SERVICE_LABEL}`]);
+        fs.writeFileSync(target, plistBody(opts));
+        const r = run("launchctl", ["bootstrap", `gui/${uid()}`, target]);
+        if (!r.ok) {
+            throw new Error(
+                `launchctl bootstrap failed (status ${r.status}): ${r.stderr.trim() || r.stdout.trim()}`,
+            );
+        }
+        return;
+    }
+
+    // linux-systemd
+    const target = unitPath();
+    ensureDir(target);
+    fs.writeFileSync(target, unitBody(opts));
+    let r = run("systemctl", ["--user", "daemon-reload"]);
+    if (!r.ok) throw new Error(`systemctl --user daemon-reload failed: ${r.stderr.trim()}`);
+    r = run("systemctl", ["--user", "enable", "--now", SERVICE_UNIT]);
+    if (!r.ok) {
+        throw new Error(
+            `systemctl --user enable --now failed (status ${r.status}): ${r.stderr.trim() || r.stdout.trim()}`,
+        );
+    }
+}
+
+export function uninstallService(): void {
+    const platform = detectPlatform();
+    if (!platform) return;
+
+    if (platform === "darwin") {
+        run("launchctl", ["bootout", `gui/${uid()}/${SERVICE_LABEL}`]);
+        try {
+            fs.unlinkSync(plistPath());
+        } catch {
+            /* already gone */
+        }
+        return;
+    }
+
+    run("systemctl", ["--user", "disable", "--now", SERVICE_UNIT]);
+    try {
+        fs.unlinkSync(unitPath());
+    } catch {
+        /* already gone */
+    }
+    run("systemctl", ["--user", "daemon-reload"]);
+}
+
+/**
+ * Start the already-installed service. Caller should check isInstalled()
+ * first; this function throws if invoked when the service isn't registered.
+ */
+export function startService(): void {
+    const platform = detectPlatform();
+    if (!platform) throw new Error("Service backend not available on this platform.");
+
+    if (platform === "darwin") {
+        if (!fs.existsSync(plistPath())) {
+            throw new Error("Service is not installed. Run: claude-max-api install-service");
+        }
+        // bootstrap brings the service up and (because RunAtLoad=true) starts
+        // it. If it's already loaded, bootstrap exits non-zero — fall back to
+        // kickstart in that case.
+        let r = run("launchctl", ["bootstrap", `gui/${uid()}`, plistPath()]);
+        if (!r.ok) {
+            r = run("launchctl", ["kickstart", `gui/${uid()}/${SERVICE_LABEL}`]);
+            if (!r.ok) {
+                throw new Error(`launchctl start failed: ${r.stderr.trim() || r.stdout.trim()}`);
+            }
+        }
+        return;
+    }
+
+    if (!fs.existsSync(unitPath())) {
+        throw new Error("Service is not installed. Run: claude-max-api install-service");
+    }
+    const r = run("systemctl", ["--user", "start", SERVICE_UNIT]);
+    if (!r.ok) throw new Error(`systemctl --user start failed: ${r.stderr.trim()}`);
+}
+
+export function stopService(): void {
+    const platform = detectPlatform();
+    if (!platform) throw new Error("Service backend not available on this platform.");
+
+    if (platform === "darwin") {
+        // bootout unloads the job and SIGTERMs the process. On a fresh install
+        // where the job was never loaded, this exits non-zero — treat that as
+        // a no-op.
+        run("launchctl", ["bootout", `gui/${uid()}/${SERVICE_LABEL}`]);
+        return;
+    }
+
+    const r = run("systemctl", ["--user", "stop", SERVICE_UNIT]);
+    if (!r.ok) throw new Error(`systemctl --user stop failed: ${r.stderr.trim()}`);
+}
+
+export function restartService(): void {
+    const platform = detectPlatform();
+    if (!platform) throw new Error("Service backend not available on this platform.");
+
+    if (platform === "darwin") {
+        if (!fs.existsSync(plistPath())) {
+            throw new Error("Service is not installed. Run: claude-max-api install-service");
+        }
+        // -k SIGTERMs the current instance and KeepAlive brings it back up.
+        // If the service wasn't running, kickstart alone starts it.
+        let r = run("launchctl", ["kickstart", "-k", `gui/${uid()}/${SERVICE_LABEL}`]);
+        if (!r.ok) {
+            // May not be loaded yet — bootstrap brings it up fresh.
+            r = run("launchctl", ["bootstrap", `gui/${uid()}`, plistPath()]);
+            if (!r.ok) throw new Error(`launchctl restart failed: ${r.stderr.trim()}`);
+        }
+        return;
+    }
+
+    const r = run("systemctl", ["--user", "restart", SERVICE_UNIT]);
+    if (!r.ok) throw new Error(`systemctl --user restart failed: ${r.stderr.trim()}`);
+}

--- a/src/server/standalone.ts
+++ b/src/server/standalone.ts
@@ -19,6 +19,7 @@
  * pidfile once the listener is up.
  */
 import fs from "node:fs";
+import http from "node:http";
 import { spawn } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { startServer, stopServer } from "./index.js";
@@ -33,6 +34,7 @@ import {
     waitForPidFile,
     writePidFile,
 } from "./daemon.js";
+import type { RequestEntryJSON } from "./request-tracker.js";
 
 const DEFAULT_PORT = 3456;
 const SUBCOMMANDS = new Set([
@@ -41,6 +43,7 @@ const SUBCOMMANDS = new Set([
     "restart",
     "status",
     "logs",
+    "mon",
     "help",
     "--help",
     "-h",
@@ -65,6 +68,7 @@ function printHelp(): void {
   claude-max-api restart [port]   Stop then start in the background
   claude-max-api status           Show whether the daemon is running
   claude-max-api logs [-f]        Print (or follow) the daemon log file
+  claude-max-api mon [-n NUM]     Monitor recent requests (default 20, -1 = all)
   claude-max-api help             Show this help
 
 State files:
@@ -218,6 +222,111 @@ function cmdLogs(follow: boolean): void {
     }
 }
 
+// ── Monitor helpers ───────────────────────────────────────────────
+
+interface MonitorResponse {
+    requests: RequestEntryJSON[];
+    active: number;
+    maxConcurrent: number;
+    timestamp: string;
+}
+
+function httpGet(url: string): Promise<string> {
+    return new Promise((resolve, reject) => {
+        http.get(url, (res) => {
+            let data = "";
+            res.on("data", (chunk: Buffer) => { data += chunk.toString(); });
+            res.on("end", () => resolve(data));
+        }).on("error", reject);
+    });
+}
+
+function formatBytes(bytes: number): string {
+    if (bytes < 1024) return `${bytes} B`;
+    const kb = bytes / 1024;
+    if (kb < 1024) return `${kb.toFixed(1)} KB`;
+    const mb = kb / 1024;
+    return `${mb.toFixed(1)} MB`;
+}
+
+function formatElapsed(ms: number): string {
+    if (ms < 1000) return `${ms}ms`;
+    const s = ms / 1000;
+    if (s < 60) return `${s.toFixed(1)}s`;
+    const m = Math.floor(s / 60);
+    const rem = s - m * 60;
+    return `${m}m${rem.toFixed(0)}s`;
+}
+
+function renderTable(data: MonitorResponse, port: number): string {
+    const lines: string[] = [];
+    lines.push(`Claude Max API \u2014 Request Monitor (port ${port})`);
+    lines.push("\u2501".repeat(76));
+    lines.push(
+        ` ${"Request ID".padEnd(26)} ${"Input".padStart(9)} ${"Output".padStart(9)} ${"Status".padEnd(14)} ${"Elapsed".padStart(8)}`,
+    );
+    lines.push("\u2500".repeat(76));
+
+    if (data.requests.length === 0) {
+        lines.push("  (no requests yet)");
+    } else {
+        for (const r of data.requests) {
+            const id = r.id.length > 24 ? r.id.slice(0, 22) + ".." : r.id.padEnd(24);
+            const input = formatBytes(r.inputLength).padStart(9);
+            const output = formatBytes(r.outputLength).padStart(9);
+            const status = r.status.padEnd(14);
+            const elapsed = formatElapsed(r.elapsedMs).padStart(8);
+            lines.push(` ${id}  ${input} ${output}  ${status} ${elapsed}`);
+        }
+    }
+
+    lines.push("\u2501".repeat(76));
+    const ts = data.timestamp.replace("T", " ").replace(/\.\d+Z$/, "");
+    lines.push(
+        ` Active: ${data.active} / ${data.maxConcurrent}    Total: ${data.requests.length}    Updated: ${ts}`,
+    );
+    return lines.join("\n");
+}
+
+async function cmdMon(port: number, n: number): Promise<void> {
+    const url = `http://127.0.0.1:${port}/v1/requests?n=${n}`;
+
+    // Verify connectivity once before entering the loop.
+    try {
+        await httpGet(`http://127.0.0.1:${port}/health`);
+    } catch {
+        console.error(`Cannot reach server at http://127.0.0.1:${port}. Is it running?`);
+        process.exit(1);
+    }
+
+    let running = true;
+    const shutdown = () => {
+        running = false;
+        // Show cursor again and move below the table.
+        process.stdout.write("\x1b[?25h");
+        process.exit(0);
+    };
+    process.on("SIGINT", shutdown);
+    process.on("SIGTERM", shutdown);
+
+    // Hide cursor for cleaner refreshes.
+    process.stdout.write("\x1b[?25l");
+
+    while (running) {
+        try {
+            const raw = await httpGet(url);
+            const data: MonitorResponse = JSON.parse(raw);
+            // Clear screen and move cursor to top-left.
+            process.stdout.write("\x1b[2J\x1b[H");
+            process.stdout.write(renderTable(data, port) + "\n");
+        } catch {
+            process.stdout.write("\x1b[2J\x1b[H");
+            process.stdout.write(`Connection lost to http://127.0.0.1:${port} \u2014 retrying...\n`);
+        }
+        await new Promise((r) => setTimeout(r, 1000));
+    }
+}
+
 async function main(): Promise<void> {
     const arg0 = process.argv[2];
 
@@ -245,6 +354,23 @@ async function main(): Promise<void> {
             case "logs": {
                 const follow = process.argv[3] === "-f" || process.argv[3] === "--follow";
                 cmdLogs(follow);
+                return;
+            }
+            case "mon": {
+                // Parse -n NUMBER from remaining args
+                let monN = 20;
+                const monArgs = process.argv.slice(3);
+                for (let i = 0; i < monArgs.length; i++) {
+                    if (monArgs[i] === "-n" && i + 1 < monArgs.length) {
+                        monN = parseInt(monArgs[i + 1], 10);
+                        if (isNaN(monN)) monN = 20;
+                        break;
+                    }
+                }
+                // Determine port from running daemon or fall back to default.
+                const daemon = getRunningDaemon();
+                const monPort = daemon?.port ?? DEFAULT_PORT;
+                await cmdMon(monPort, monN);
                 return;
             }
             case "help":

--- a/src/server/standalone.ts
+++ b/src/server/standalone.ts
@@ -1,29 +1,82 @@
 #!/usr/bin/env node
 /**
- * Standalone server for testing without OpenClaw
+ * Standalone server entry point for `claude-max-api`.
  *
  * Usage:
- *   npm run start
- *   # or
- *   node dist/server/standalone.js [port]
+ *   claude-max-api                  Run in the foreground (default port 3456)
+ *   claude-max-api 3457             Run in the foreground on port 3457
+ *   claude-max-api start [port]     Daemonize and return immediately
+ *   claude-max-api stop             Stop the running daemon
+ *   claude-max-api restart [port]   Stop then start in the background
+ *   claude-max-api status           Show whether the daemon is running
+ *   claude-max-api logs [-f]        Print (or follow) the daemon log file
+ *
+ * The `start` family of commands uses ~/.claude-max-api/proxy.pid as a
+ * pidfile and ~/.claude-max-api/proxy.log as the redirected log file.
+ *
+ * The hidden `--foreground` argument is what the parent passes to the
+ * background child after spawning it; it makes the child write its own
+ * pidfile once the listener is up.
  */
+import fs from "node:fs";
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
 import { startServer, stopServer } from "./index.js";
 import { verifyClaude, verifyAuth } from "../subprocess/manager.js";
+import {
+    LOG_FILE,
+    PID_FILE,
+    daemonize,
+    getRunningDaemon,
+    removePidFile,
+    stopDaemon,
+    waitForPidFile,
+    writePidFile,
+} from "./daemon.js";
 
 const DEFAULT_PORT = 3456;
+const SUBCOMMANDS = new Set([
+    "start",
+    "stop",
+    "restart",
+    "status",
+    "logs",
+    "help",
+    "--help",
+    "-h",
+]);
 
-async function main() {
+function parsePort(arg: string | undefined): number {
+    if (!arg) return DEFAULT_PORT;
+    const port = parseInt(arg, 10);
+    if (isNaN(port) || port < 1 || port > 65535) {
+        console.error(`Invalid port: ${arg}`);
+        process.exit(1);
+    }
+    return port;
+}
+
+function printHelp(): void {
+    console.log(`Usage:
+  claude-max-api                  Run in the foreground (default port ${DEFAULT_PORT})
+  claude-max-api <port>           Run in the foreground on the given port
+  claude-max-api start [port]     Daemonize and return immediately
+  claude-max-api stop             Stop the running daemon
+  claude-max-api restart [port]   Stop then start in the background
+  claude-max-api status           Show whether the daemon is running
+  claude-max-api logs [-f]        Print (or follow) the daemon log file
+  claude-max-api help             Show this help
+
+State files:
+  pidfile: ${PID_FILE}
+  log:     ${LOG_FILE}
+`);
+}
+
+async function runForeground(port: number, registerPidFile: boolean): Promise<void> {
     console.log("Claude Code CLI Provider - Standalone Server");
     console.log("============================================\n");
 
-    // Parse port from command line
-    const port = parseInt(process.argv[2] || String(DEFAULT_PORT), 10);
-    if (isNaN(port) || port < 1 || port > 65535) {
-        console.error(`Invalid port: ${process.argv[2]}`);
-        process.exit(1);
-    }
-
-    // Verify Claude CLI
     console.log("Checking Claude CLI...");
     const cliCheck = await verifyClaude();
     if (!cliCheck.ok) {
@@ -32,7 +85,6 @@ async function main() {
     }
     console.log(`  Claude CLI: ${cliCheck.version || "OK"}`);
 
-    // Verify authentication
     console.log("Checking authentication...");
     const authCheck = await verifyAuth();
     if (!authCheck.ok) {
@@ -42,31 +94,170 @@ async function main() {
     }
     console.log("  Authentication: OK\n");
 
-    // Start server
     try {
         await startServer({ port });
-        console.log("\nServer ready. Test with:");
-        console.log(
-            `  curl -X POST http://localhost:${port}/v1/chat/completions \\`
-        );
-        console.log(`    -H "Content-Type: application/json" \\`);
-        console.log(
-            `    -d '{"model": "claude-sonnet-4", "messages": [{"role": "user", "content": "Hello!"}]}'`
-        );
-        console.log("\nPress Ctrl+C to stop.\n");
     } catch (err) {
         console.error("Failed to start server:", err);
         process.exit(1);
     }
 
-    // Handle graceful shutdown
+    if (registerPidFile) {
+        writePidFile({
+            pid: process.pid,
+            port,
+            startedAt: new Date().toISOString(),
+        });
+        console.log(`[Daemon] Registered pidfile at ${PID_FILE}`);
+    }
+
+    console.log("\nServer ready. Test with:");
+    console.log(`  curl -X POST http://localhost:${port}/v1/chat/completions \\`);
+    console.log(`    -H "Content-Type: application/json" \\`);
+    console.log(
+        `    -d '{"model": "claude-sonnet-4", "messages": [{"role": "user", "content": "Hello!"}]}'`,
+    );
+    if (registerPidFile) {
+        console.log("\nRunning in background. Send SIGTERM (or `claude-max-api stop`) to stop.\n");
+    } else {
+        console.log("\nPress Ctrl+C to stop.\n");
+    }
+
     const shutdown = async () => {
         console.log("\nShutting down...");
+        if (registerPidFile) removePidFile();
         await stopServer();
         process.exit(0);
     };
     process.on("SIGINT", shutdown);
     process.on("SIGTERM", shutdown);
+}
+
+async function cmdStart(port: number): Promise<void> {
+    const existing = getRunningDaemon();
+    if (existing) {
+        console.error(
+            `Server is already running (pid ${existing.pid}, port ${existing.port}). Use 'stop' or 'restart' first.`,
+        );
+        process.exit(1);
+    }
+
+    const scriptPath = fileURLToPath(import.meta.url);
+    const childPid = daemonize(scriptPath, [String(port)]);
+    console.log(
+        `Starting Claude Max API proxy in the background (initial pid ${childPid})...`,
+    );
+    try {
+        const info = await waitForPidFile();
+        console.log(`Server is running (pid ${info.pid}) on port ${info.port}.`);
+        console.log(`Logs: ${LOG_FILE}`);
+    } catch (err) {
+        console.error(`Failed to confirm background startup: ${(err as Error).message}`);
+        process.exit(1);
+    }
+}
+
+async function cmdStop(): Promise<void> {
+    const result = await stopDaemon();
+    if (result.pid === null) {
+        console.log("No running server (no pidfile or stale pidfile).");
+        return;
+    }
+    if (result.stopped) {
+        console.log(`Stopped server (pid ${result.pid}).`);
+    } else {
+        console.error(`Failed to stop server (pid ${result.pid}).`);
+        process.exit(1);
+    }
+}
+
+function cmdStatus(): void {
+    const info = getRunningDaemon();
+    if (!info) {
+        console.log("Not running.");
+        // systemd-style "program not running" exit code, so shell scripts can
+        // distinguish "not running" from a real error like "permission denied".
+        process.exit(3);
+    }
+    console.log(
+        `Running (pid ${info.pid}) on port ${info.port}, started ${info.startedAt}.`,
+    );
+    console.log(`Logs: ${LOG_FILE}`);
+}
+
+async function cmdRestart(port: number): Promise<void> {
+    const result = await stopDaemon();
+    if (result.stopped) {
+        console.log(`Stopped previous server (pid ${result.pid}).`);
+    }
+    await cmdStart(port);
+}
+
+function cmdLogs(follow: boolean): void {
+    if (!fs.existsSync(LOG_FILE)) {
+        console.log(`No logs yet at ${LOG_FILE}.`);
+        return;
+    }
+    if (follow) {
+        // Use tail -f rather than reimplementing it. tail is on every Unix
+        // system the proxy is expected to run on (Linux + macOS).
+        const tail = spawn("tail", ["-n", "200", "-f", LOG_FILE], {
+            stdio: "inherit",
+        });
+        tail.on("exit", (code) => process.exit(code ?? 0));
+        const forward = (sig: NodeJS.Signals) => {
+            try {
+                tail.kill(sig);
+            } catch {
+                /* ignore */
+            }
+        };
+        process.on("SIGINT", () => forward("SIGINT"));
+        process.on("SIGTERM", () => forward("SIGTERM"));
+    } else {
+        process.stdout.write(fs.readFileSync(LOG_FILE));
+    }
+}
+
+async function main(): Promise<void> {
+    const arg0 = process.argv[2];
+
+    // Internal: invoked by daemonize() in the background child.
+    if (arg0 === "--foreground") {
+        const port = parsePort(process.argv[3]);
+        await runForeground(port, true);
+        return;
+    }
+
+    if (arg0 && SUBCOMMANDS.has(arg0)) {
+        switch (arg0) {
+            case "start":
+                await cmdStart(parsePort(process.argv[3]));
+                return;
+            case "stop":
+                await cmdStop();
+                return;
+            case "restart":
+                await cmdRestart(parsePort(process.argv[3]));
+                return;
+            case "status":
+                cmdStatus();
+                return;
+            case "logs": {
+                const follow = process.argv[3] === "-f" || process.argv[3] === "--follow";
+                cmdLogs(follow);
+                return;
+            }
+            case "help":
+            case "--help":
+            case "-h":
+                printHelp();
+                return;
+        }
+    }
+
+    // Backwards compat: `claude-max-api [port]` runs in the foreground.
+    const port = parsePort(arg0);
+    await runForeground(port, false);
 }
 
 main().catch((err) => {

--- a/src/server/standalone.ts
+++ b/src/server/standalone.ts
@@ -34,6 +34,16 @@ import {
     waitForPidFile,
     writePidFile,
 } from "./daemon.js";
+import {
+    detectPlatform,
+    installService,
+    isInstalled,
+    restartService,
+    serviceStatus,
+    startService,
+    stopService,
+    uninstallService,
+} from "./service.js";
 import type { RequestEntryJSON } from "./request-tracker.js";
 
 const DEFAULT_PORT = 3456;
@@ -44,6 +54,8 @@ const SUBCOMMANDS = new Set([
     "status",
     "logs",
     "mon",
+    "install-service",
+    "uninstall-service",
     "help",
     "--help",
     "-h",
@@ -61,15 +73,17 @@ function parsePort(arg: string | undefined): number {
 
 function printHelp(): void {
     console.log(`Usage:
-  claude-max-api                  Run in the foreground (default port ${DEFAULT_PORT})
-  claude-max-api <port>           Run in the foreground on the given port
-  claude-max-api start [port]     Daemonize and return immediately
-  claude-max-api stop             Stop the running daemon
-  claude-max-api restart [port]   Stop then start in the background
-  claude-max-api status           Show whether the daemon is running
-  claude-max-api logs [-f]        Print (or follow) the daemon log file
-  claude-max-api mon [-n NUM]     Monitor recent requests (default 20, -1 = all)
-  claude-max-api help             Show this help
+  claude-max-api                         Run in the foreground (default port ${DEFAULT_PORT})
+  claude-max-api <port>                  Run in the foreground on the given port
+  claude-max-api install-service [port]  Register as a login service (launchd/systemd) and start it
+  claude-max-api uninstall-service       Stop the service and remove its unit file
+  claude-max-api start [port]            Start the service (falls back to built-in daemon if no service backend)
+  claude-max-api stop                    Stop the service (or built-in daemon)
+  claude-max-api restart [port]          Restart the service (or built-in daemon)
+  claude-max-api status                  Show service + daemon status
+  claude-max-api logs [-f]               Print (or follow) the log file
+  claude-max-api mon [-n NUM]            Monitor recent requests (default 20, -1 = all)
+  claude-max-api help                    Show this help
 
 State files:
   pidfile: ${PID_FILE}
@@ -136,7 +150,64 @@ async function runForeground(port: number, registerPidFile: boolean): Promise<vo
     process.on("SIGTERM", shutdown);
 }
 
+/**
+ * Start the proxy.
+ *
+ * Preferred path: use the OS service (launchd / systemd user unit) that was
+ * registered at install time. If the service isn't installed yet but the
+ * platform supports one, auto-install it so the user never has to think about
+ * it — this matches `npm install -g`'s postinstall behavior but also covers
+ * the case where someone built from source.
+ *
+ * Fallback: if the platform has no service backend (rare: non-systemd Linux,
+ * Windows, etc.) fall back to the self-daemonize path.
+ */
 async function cmdStart(port: number): Promise<void> {
+    const platform = detectPlatform();
+    if (!platform) {
+        await cmdStartDaemon(port);
+        return;
+    }
+
+    if (!isInstalled()) {
+        console.log(`Installing service on ${platform}...`);
+        try {
+            installService(port);
+        } catch (err) {
+            console.error(`install-service failed: ${(err as Error).message}`);
+            process.exit(1);
+        }
+        // RunAtLoad / enable --now already brought it up as part of install.
+        const info = await waitForPidFile().catch(() => null);
+        if (info) {
+            console.log(`Service started (pid ${info.pid}) on port ${info.port}.`);
+            console.log(`Logs: ${LOG_FILE}`);
+        } else {
+            console.log(`Service installed. Use 'claude-max-api status' to verify.`);
+        }
+        return;
+    }
+
+    try {
+        startService();
+    } catch (err) {
+        console.error(`start failed: ${(err as Error).message}`);
+        process.exit(1);
+    }
+    const info = await waitForPidFile(5000).catch(() => null);
+    if (info) {
+        console.log(`Service started (pid ${info.pid}) on port ${info.port}.`);
+        console.log(`Logs: ${LOG_FILE}`);
+    } else {
+        console.log(`Service start requested. Use 'claude-max-api status' to verify.`);
+    }
+}
+
+/**
+ * Legacy self-daemonize path. Only invoked when the platform has no service
+ * backend (detectPlatform() returned null).
+ */
+async function cmdStartDaemon(port: number): Promise<void> {
     const existing = getRunningDaemon();
     if (existing) {
         console.error(
@@ -148,7 +219,7 @@ async function cmdStart(port: number): Promise<void> {
     const scriptPath = fileURLToPath(import.meta.url);
     const childPid = daemonize(scriptPath, [String(port)]);
     console.log(
-        `Starting Claude Max API proxy in the background (initial pid ${childPid})...`,
+        `No service backend on this platform — starting Claude Max API proxy in the background (initial pid ${childPid})...`,
     );
     try {
         const info = await waitForPidFile();
@@ -161,39 +232,144 @@ async function cmdStart(port: number): Promise<void> {
 }
 
 async function cmdStop(): Promise<void> {
+    const platform = detectPlatform();
+
+    // Service path: ask launchd/systemd to stop the job. This SIGTERMs the
+    // running child, which triggers its shutdown handler and removes the
+    // pidfile on its own.
+    if (platform && isInstalled()) {
+        try {
+            stopService();
+        } catch (err) {
+            console.error(`stop failed: ${(err as Error).message}`);
+            process.exit(1);
+        }
+        // Wait briefly for the pidfile to disappear so status feels synchronous.
+        const until = Date.now() + 5000;
+        while (Date.now() < until && getRunningDaemon()) {
+            await new Promise((r) => setTimeout(r, 100));
+        }
+        if (!getRunningDaemon()) {
+            removePidFile();
+            console.log("Service stopped.");
+        } else {
+            console.log("Stop requested. Verify with 'claude-max-api status'.");
+        }
+        return;
+    }
+
+    // Legacy/fallback path: SIGTERM the pidfile-tracked daemon directly.
     const result = await stopDaemon();
     if (result.pid === null) {
-        console.log("No running server (no pidfile or stale pidfile).");
+        console.log("No running server (no service installed and no pidfile).");
         return;
     }
     if (result.stopped) {
-        console.log(`Stopped server (pid ${result.pid}).`);
+        console.log(`Stopped daemon (pid ${result.pid}).`);
     } else {
-        console.error(`Failed to stop server (pid ${result.pid}).`);
+        console.error(`Failed to stop daemon (pid ${result.pid}).`);
         process.exit(1);
     }
 }
 
 function cmdStatus(): void {
     const info = getRunningDaemon();
-    if (!info) {
-        console.log("Not running.");
-        // systemd-style "program not running" exit code, so shell scripts can
-        // distinguish "not running" from a real error like "permission denied".
-        process.exit(3);
+    const svc = serviceStatus();
+
+    if (svc.installed) {
+        console.log(`Service: installed (${svc.detail})`);
+    } else {
+        const platform = detectPlatform();
+        console.log(
+            platform
+                ? `Service: not installed (platform: ${platform})`
+                : `Service: unsupported platform (${process.platform})`,
+        );
     }
-    console.log(
-        `Running (pid ${info.pid}) on port ${info.port}, started ${info.startedAt}.`,
-    );
+
+    if (info) {
+        console.log(
+            `Process: running (pid ${info.pid}) on port ${info.port}, started ${info.startedAt}.`,
+        );
+        console.log(`Logs: ${LOG_FILE}`);
+        return;
+    }
+
+    console.log("Process: not running.");
     console.log(`Logs: ${LOG_FILE}`);
+    // systemd-style "program not running" exit code.
+    process.exit(3);
 }
 
 async function cmdRestart(port: number): Promise<void> {
+    const platform = detectPlatform();
+
+    if (platform && isInstalled()) {
+        try {
+            restartService();
+        } catch (err) {
+            console.error(`restart failed: ${(err as Error).message}`);
+            process.exit(1);
+        }
+        const info = await waitForPidFile(5000).catch(() => null);
+        if (info) {
+            console.log(`Service restarted (pid ${info.pid}) on port ${info.port}.`);
+        } else {
+            console.log("Service restart requested. Verify with 'claude-max-api status'.");
+        }
+        return;
+    }
+
+    // Fallback: stop the daemon (if any) and re-spawn via the legacy path.
     const result = await stopDaemon();
     if (result.stopped) {
-        console.log(`Stopped previous server (pid ${result.pid}).`);
+        console.log(`Stopped previous daemon (pid ${result.pid}).`);
     }
-    await cmdStart(port);
+    await cmdStartDaemon(port);
+    // Note on the port arg: changing port requires uninstall-service + reinstall
+    // on the service path, since the plist/unit bakes in the original port.
+    void port;
+}
+
+async function cmdInstallService(port: number): Promise<void> {
+    const platform = detectPlatform();
+    if (!platform) {
+        console.error(
+            `No service backend available on ${process.platform}. Use 'claude-max-api start' for the built-in daemon.`,
+        );
+        process.exit(1);
+    }
+    const wasInstalled = isInstalled();
+    try {
+        installService(port);
+    } catch (err) {
+        console.error(`install-service failed: ${(err as Error).message}`);
+        process.exit(1);
+    }
+    console.log(
+        `Service ${wasInstalled ? "updated" : "installed"} on ${platform}, listening on port ${port}.`,
+    );
+    console.log("It will start automatically on login.");
+    console.log(`Logs: ${LOG_FILE}`);
+}
+
+function cmdUninstallService(): void {
+    const platform = detectPlatform();
+    if (!platform) {
+        console.log(`No service backend on ${process.platform}; nothing to uninstall.`);
+        return;
+    }
+    if (!isInstalled()) {
+        console.log("Service is not installed.");
+        return;
+    }
+    try {
+        uninstallService();
+    } catch (err) {
+        console.error(`uninstall-service failed: ${(err as Error).message}`);
+        process.exit(1);
+    }
+    console.log("Service stopped and unit file removed.");
 }
 
 function cmdLogs(follow: boolean): void {
@@ -356,6 +532,12 @@ async function main(): Promise<void> {
                 cmdLogs(follow);
                 return;
             }
+            case "install-service":
+                await cmdInstallService(parsePort(process.argv[3]));
+                return;
+            case "uninstall-service":
+                cmdUninstallService();
+                return;
             case "mon": {
                 // Parse -n NUMBER from remaining args
                 let monN = 20;

--- a/src/subprocess/manager.ts
+++ b/src/subprocess/manager.ts
@@ -310,7 +310,14 @@ export class ClaudeSubprocess extends EventEmitter {
                     this.emit("result", message);
                 }
             } catch {
-                // Non-JSON output, emit as raw
+                // The CLI usually emits stream-json on stdout, but if it ever
+                // dumps a non-JSON line (panic stack trace, "Sandbox violation:",
+                // permission prompt) we surface it instead of silently
+                // swallowing it via the unconsumed 'raw' event.
+                console.error(
+                    "[Subprocess] Non-JSON stdout line:",
+                    trimmed.slice(0, 500),
+                );
                 this.emit("raw", trimmed);
             }
         }

--- a/src/subprocess/manager.ts
+++ b/src/subprocess/manager.ts
@@ -129,7 +129,19 @@ export class ClaudeSubprocess extends EventEmitter {
                 `stdin=${stdinBytes}B (prompt=${promptBytes}B systemPrompt=${sysPromptBytes}B)`,
         );
 
-        return new Promise((resolve, reject) => {
+        return new Promise<void>((resolve, reject) => {
+            // Settle once: we either resolve on the spawn handshake or reject
+            // on a spawn error, but never both. After the start() promise has
+            // resolved, any further child errors are surfaced as ClaudeSubprocess
+            // 'error' events instead so consumers can handle them in-stream.
+            let settled = false;
+            const wrapSpawnError = (err: Error): Error =>
+                err.message.includes("ENOENT")
+                    ? new Error(
+                          "Claude CLI not found. Install with: npm install -g @anthropic-ai/claude-code"
+                      )
+                    : err;
+
             try {
                 // Use spawn() for security - no shell interpretation
                 this.process = spawn("claude", args, {
@@ -142,17 +154,32 @@ export class ClaudeSubprocess extends EventEmitter {
                 this.activityTimeout = ACTIVITY_TIMEOUT;
                 this.resetActivityTimeout();
 
-                // Handle spawn errors (e.g., claude not found)
+                // The 'spawn' event fires once the child has actually been
+                // forked. Defer resolving start() until then so async spawn
+                // errors (e.g. ENOENT) reach the caller as a real rejection
+                // instead of being silently swallowed by an already-resolved
+                // promise.
+                this.process.once("spawn", () => {
+                    if (settled) return;
+                    settled = true;
+                    console.error(
+                        `[Subprocess] Process spawned with PID: ${this.process?.pid} (${stdinBytes} bytes via stdin)`
+                    );
+                    resolve();
+                });
+
+                // Handle child errors. Before the start() promise has settled,
+                // surface them as a rejection so the HTTP layer can produce a
+                // proper 5xx. After settling, re-emit them so streaming
+                // consumers can react in-band.
                 this.process.on("error", (err) => {
-                    this.clearTimeout();
-                    if (err.message.includes("ENOENT")) {
-                        reject(
-                            new Error(
-                                "Claude CLI not found. Install with: npm install -g @anthropic-ai/claude-code"
-                            )
-                        );
+                    const wrapped = wrapSpawnError(err);
+                    if (!settled) {
+                        settled = true;
+                        this.clearTimeout();
+                        reject(wrapped);
                     } else {
-                        reject(err);
+                        this.emit("error", wrapped);
                     }
                 });
 
@@ -167,9 +194,6 @@ export class ClaudeSubprocess extends EventEmitter {
                     });
                     stdin.end(stdinPayload, "utf8");
                 }
-                console.error(
-                    `[Subprocess] Process spawned with PID: ${this.process.pid} (${stdinBytes} bytes via stdin)`
-                );
 
                 // Parse JSON stream from stdout
                 this.process.stdout?.on("data", (chunk: Buffer) => {
@@ -206,12 +230,13 @@ export class ClaudeSubprocess extends EventEmitter {
                     }
                     this.emit("close", code);
                 });
-
-                // Resolve immediately since we're streaming
-                resolve();
             } catch (err) {
-                this.clearTimeout();
-                reject(err);
+                // Synchronous spawn failures (e.g. EACCES, E2BIG) end up here.
+                if (!settled) {
+                    settled = true;
+                    this.clearTimeout();
+                    reject(err as Error);
+                }
             }
         });
     }

--- a/src/subprocess/manager.ts
+++ b/src/subprocess/manager.ts
@@ -275,7 +275,7 @@ export class ClaudeSubprocess extends EventEmitter {
      * prompt is given.
      */
     private buildArgs(options: SubprocessOptions): string[] {
-        return [
+        const args = [
             "--print",
             "--output-format",
             "stream-json",
@@ -283,8 +283,14 @@ export class ClaudeSubprocess extends EventEmitter {
             "--include-partial-messages",
             "--model",
             options.model,
-            "--dangerously-skip-permissions",
         ];
+        // Safe mode: opt out of --dangerously-skip-permissions, which would
+        // otherwise let any input that reaches the proxy run arbitrary Bash on
+        // the host. See README "Security model" for the trade-off.
+        if (process.env.CLAUDE_PROXY_SAFE_MODE !== "1") {
+            args.push("--dangerously-skip-permissions");
+        }
+        return args;
     }
 
     /**

--- a/src/subprocess/manager.ts
+++ b/src/subprocess/manager.ts
@@ -92,8 +92,15 @@ export class ClaudeSubprocess extends EventEmitter {
         // which blows past Linux ARG_MAX (~128 KiB) and causes spawn E2BIG.
         // Claude reliably follows instructions placed at the top of the
         // user message inside a labeled block.
+        //
+        // Because we no longer use --system-prompt, Claude Code's built-in
+        // system prompt is still in effect. The override banner tells the
+        // model that anything inside the [System Instructions] block takes
+        // precedence over default Claude Code behavior, so OpenClaw rules
+        // (e.g. "always reply in Chinese", "never use Bash for X") still
+        // win when they conflict with the default agent behavior.
         const stdinPayload = options.systemPrompt
-            ? `[System Instructions]\n${options.systemPrompt}\n[End System Instructions]\n\n${prompt}`
+            ? `[System Instructions]\nThe rules in this block override any default Claude Code behavior. When they conflict with built-in defaults, follow these rules.\n\n${options.systemPrompt}\n[End System Instructions]\n\n${prompt}`
             : prompt;
 
         // Build the env we'll hand to spawn separately so we can measure it.

--- a/src/subprocess/manager.ts
+++ b/src/subprocess/manager.ts
@@ -113,9 +113,12 @@ export class ClaudeSubprocess extends EventEmitter {
             : prompt;
 
         // Build the env we'll hand to spawn separately so we can measure it.
+        // Note: assigning `CLAUDECODE: undefined` in an object spread does NOT
+        // remove the key — Node forwards undefined values to the child as the
+        // literal string "undefined". To actually unset CLAUDECODE we have to
+        // delete the key after the spread.
         const childEnv: NodeJS.ProcessEnv = {
             ...process.env,
-            CLAUDECODE: undefined,
             // Ensure oc-tool is findable and can reach the gateway
             PATH: [
                 path.join(process.env.HOME || "/tmp", ".openclaw", "bin"),
@@ -124,6 +127,7 @@ export class ClaudeSubprocess extends EventEmitter {
             OPENCLAW_GATEWAY_TOKEN: resolveGatewayToken() ?? undefined,
             OPENCLAW_GATEWAY_URL: process.env.OPENCLAW_GATEWAY_URL ?? "http://localhost:18789",
         };
+        delete childEnv.CLAUDECODE;
 
         // Diagnostics: log argv + envp sizes so we can spot ARG_MAX (E2BIG) blowups.
         // Linux ARG_MAX is typically 128 KiB and counts argv + envp combined.

--- a/src/subprocess/manager.ts
+++ b/src/subprocess/manager.ts
@@ -85,24 +85,56 @@ export class ClaudeSubprocess extends EventEmitter {
      * Start the Claude CLI subprocess with the given prompt
      */
     async start(prompt: string, options: SubprocessOptions): Promise<void> {
-        const args = this.buildArgs(prompt, options);
+        const args = this.buildArgs(options);
+
+        // Inline the system prompt into stdin instead of passing it via
+        // --system-prompt. The OpenClaw system prompt can exceed 150 KB,
+        // which blows past Linux ARG_MAX (~128 KiB) and causes spawn E2BIG.
+        // Claude reliably follows instructions placed at the top of the
+        // user message inside a labeled block.
+        const stdinPayload = options.systemPrompt
+            ? `[System Instructions]\n${options.systemPrompt}\n[End System Instructions]\n\n${prompt}`
+            : prompt;
+
+        // Build the env we'll hand to spawn separately so we can measure it.
+        const childEnv: NodeJS.ProcessEnv = {
+            ...process.env,
+            CLAUDECODE: undefined,
+            // Ensure oc-tool is findable and can reach the gateway
+            PATH: [
+                path.join(process.env.HOME || "/tmp", ".openclaw", "bin"),
+                process.env.PATH ?? "/usr/local/bin:/usr/bin:/bin",
+            ].join(":"),
+            OPENCLAW_GATEWAY_TOKEN: resolveGatewayToken() ?? undefined,
+            OPENCLAW_GATEWAY_URL: process.env.OPENCLAW_GATEWAY_URL ?? "http://localhost:18789",
+        };
+
+        // Diagnostics: log argv + envp sizes so we can spot ARG_MAX (E2BIG) blowups.
+        // Linux ARG_MAX is typically 128 KiB and counts argv + envp combined.
+        const argvBytes = args.reduce(
+            (sum, a) => sum + Buffer.byteLength(a, "utf8") + 1,
+            Buffer.byteLength("claude", "utf8") + 1,
+        );
+        const envpBytes = Object.entries(childEnv).reduce((sum, [k, v]) => {
+            if (v === undefined) return sum;
+            return sum + Buffer.byteLength(`${k}=${v}`, "utf8") + 1;
+        }, 0);
+        const promptBytes = Buffer.byteLength(prompt, "utf8");
+        const sysPromptBytes = options.systemPrompt
+            ? Buffer.byteLength(options.systemPrompt, "utf8")
+            : 0;
+        const stdinBytes = Buffer.byteLength(stdinPayload, "utf8");
+        console.error(
+            `[Subprocess] argv=${argvBytes}B envp=${envpBytes}B (sum=${argvBytes + envpBytes}B) ` +
+                `stdin=${stdinBytes}B (prompt=${promptBytes}B systemPrompt=${sysPromptBytes}B)`,
+        );
 
         return new Promise((resolve, reject) => {
             try {
                 // Use spawn() for security - no shell interpretation
                 this.process = spawn("claude", args, {
                     cwd: options.cwd || PROXY_CWD,
-                    env: {
-                        ...process.env,
-                        CLAUDECODE: undefined,
-                        // Ensure oc-tool is findable and can reach the gateway
-                        PATH: [
-                            path.join(process.env.HOME || "/tmp", ".openclaw", "bin"),
-                            process.env.PATH ?? "/usr/local/bin:/usr/bin:/bin",
-                        ].join(":"),
-                        OPENCLAW_GATEWAY_TOKEN: resolveGatewayToken() ?? undefined,
-                        OPENCLAW_GATEWAY_URL: process.env.OPENCLAW_GATEWAY_URL ?? "http://localhost:18789",
-                    },
+                    env: childEnv,
                     stdio: ["pipe", "pipe", "pipe"],
                 });
 
@@ -124,10 +156,19 @@ export class ClaudeSubprocess extends EventEmitter {
                     }
                 });
 
-                // Close stdin since we pass prompt as argument
-                this.process.stdin?.end();
+                // Pipe the prompt (and inlined system prompt) via stdin instead
+                // of argv to avoid E2BIG. Linux execve ARG_MAX is ~128 KiB and
+                // counts argv + envp combined; OpenClaw conversations + system
+                // prompts routinely exceed that on the command line.
+                const stdin = this.process.stdin;
+                if (stdin) {
+                    stdin.on("error", (err) => {
+                        console.error("[Subprocess] stdin error:", err.message);
+                    });
+                    stdin.end(stdinPayload, "utf8");
+                }
                 console.error(
-                    `[Subprocess] Process spawned with PID: ${this.process.pid}`
+                    `[Subprocess] Process spawned with PID: ${this.process.pid} (${stdinBytes} bytes via stdin)`
                 );
 
                 // Parse JSON stream from stdout
@@ -176,10 +217,16 @@ export class ClaudeSubprocess extends EventEmitter {
     }
 
     /**
-     * Build CLI arguments array
+     * Build CLI arguments array.
+     *
+     * Note: neither the user prompt nor the system prompt is passed as argv —
+     * both are piped via stdin in start() (system prompt inlined as a labeled
+     * block at the top) to avoid E2BIG on long conversation histories or huge
+     * OpenClaw system prompts. claude --print reads stdin when no positional
+     * prompt is given.
      */
-    private buildArgs(prompt: string, options: SubprocessOptions): string[] {
-        const args = [
+    private buildArgs(options: SubprocessOptions): string[] {
+        return [
             "--print",
             "--output-format",
             "stream-json",
@@ -189,14 +236,6 @@ export class ClaudeSubprocess extends EventEmitter {
             options.model,
             "--dangerously-skip-permissions",
         ];
-
-        // Pass system prompt as a native CLI flag
-        if (options.systemPrompt) {
-            args.push("--system-prompt", options.systemPrompt);
-        }
-
-        args.push("--", prompt);
-        return args;
     }
 
     /**

--- a/src/subprocess/manager.ts
+++ b/src/subprocess/manager.ts
@@ -55,7 +55,16 @@ function resolveGatewayToken(): string | null {
     return _gatewayToken;
 }
 
-const ACTIVITY_TIMEOUT = 600_000; // 10 minutes (no stdout activity = stuck)
+// Activity watchdog: if the CLI emits nothing on stdout *or* stderr for
+// this many milliseconds, we assume it is wedged and SIGTERM it. The default
+// is 10 minutes; tune via env for unusually long-running tools.
+const DEFAULT_ACTIVITY_TIMEOUT = 600_000;
+const ACTIVITY_TIMEOUT = (() => {
+    const raw = process.env.CLAUDE_PROXY_ACTIVITY_TIMEOUT_MS;
+    if (!raw) return DEFAULT_ACTIVITY_TIMEOUT;
+    const parsed = parseInt(raw, 10);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_ACTIVITY_TIMEOUT;
+})();
 
 export interface SubprocessOptions {
     model: ClaudeModel;
@@ -214,8 +223,12 @@ export class ClaudeSubprocess extends EventEmitter {
                     this.processBuffer();
                 });
 
-                // Capture stderr for debugging
+                // Capture stderr for debugging. stderr output also counts as
+                // activity — if the CLI is producing progress logs (or even
+                // tool execution traces) on stderr while waiting on something
+                // expensive, we should not kill it just because stdout is idle.
                 this.process.stderr?.on("data", (chunk: Buffer) => {
+                    this.resetActivityTimeout();
                     const errorText = chunk.toString().trim();
                     if (errorText) {
                         console.error(


### PR DESCRIPTION
## Summary

This PR significantly refactors the standalone server to add production-grade lifecycle management, request monitoring, and resource limits. The Telegram progress reporter and session manager have been removed in favor of a simpler, stateless architecture. The server now supports both built-in daemon mode and OS-level service integration (launchd on macOS, systemd on Linux).

## Key Changes

### Server Lifecycle & Daemon Management
- **New daemon module** (`src/server/daemon.ts`): Built-in background process management with pidfile tracking, supporting `start`, `stop`, `restart`, and `status` commands
- **New service module** (`src/server/service.ts`): Cross-platform OS service integration (launchd/systemd) that auto-starts on login; falls back to built-in daemon on unsupported platforms
- **Enhanced standalone CLI** (`src/server/standalone.ts`): Expanded from simple port argument to full subcommand interface supporting `start`, `stop`, `restart`, `status`, `logs`, `mon`, `install-service`, `uninstall-service`, and `help`
- **Post-install hook** (`src/server/install-service.ts`): Automatically registers the service on global npm install

### Request Tracking & Monitoring
- **New request tracker** (`src/server/request-tracker.ts`): In-memory circular buffer tracking recent requests (input/output bytes, status, timing) for the `/v1/requests` monitoring endpoint
- **Request lifecycle integration** in `handleChatCompletions`: Tracks request start, completion, and output bytes; enforces concurrency limits with 429 responses

### Resource Management
- **Concurrency limiting**: New `CLAUDE_PROXY_MAX_CONCURRENT` env var (default 4) caps in-flight CLI subprocesses to prevent OOM on request bursts
- **Configurable activity timeout**: `CLAUDE_PROXY_ACTIVITY_TIMEOUT_MS` env var (default 10 minutes) now applies to both stdout and stderr activity
- **System prompt inlining**: Moved from `--system-prompt` CLI arg to stdin to avoid Linux ARG_MAX limits on large prompts (>128 KiB)

### Code Cleanup
- **Removed Telegram progress reporter**: Entire `ProgressReporter` class and Telegram API integration removed from routes
- **Removed session manager**: Stateless per-request architecture; clients now supply full conversation history on each turn
- **Simplified CLI tool instructions**: Removed 4–5 KiB of inline oc-tool documentation; model can discover via `oc-tool --help`
- **Removed unused imports**: Cleaned up `extractModel`, `nodeSpawn`, `path`, `fs`, and session manager references from routes

### Testing & Documentation
- **Unit tests added**: `openai-to-cli.test.ts` and `cli-to-openai.test.ts` for adapter pure functions
- **Updated README**: Clarified stateless architecture, documented new env vars and concurrency/timeout behavior
- **Updated macOS setup guide**: Simplified to reference new `install-service` command

## Notable Implementation Details

- The daemon pidfile stores JSON with `{ pid, port, startedAt }` for liveness checks and port recovery
- Service definitions (plist/systemd unit) are generated at install time with the resolved script path, ensuring portability across npm install locations
- Request tracking uses a circular buffer (max 200 entries) to avoid unbounded memory growth
- The `--foreground` hidden argument allows the parent daemon to signal the child to write its own pidfile once the listener is up
- Null content in OpenAI messages is now normalized (literal string "null" → empty) to handle upstream serialization quirks

https://claude.ai/code/session_01MQJR4ZK2uJz2JPQYARDFM7